### PR TITLE
fix(ui): dashboard UX audit — mobile nav, sidebar groups, login polish

### DIFF
--- a/packages/client/src/components/auth/SignInTab.tsx
+++ b/packages/client/src/components/auth/SignInTab.tsx
@@ -11,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthFieldError } from "@/components/auth/AuthFieldError";
-import { AlertCircle, Eye, EyeOff, ShieldCheck } from "lucide-react";
+import { AlertCircle, Eye, EyeOff, Loader2, ShieldCheck } from "lucide-react";
 
 type AuthClientResult<TData> = {
   data?: TData | null;
@@ -167,7 +167,14 @@ export function SignInTab({ onAuthenticated }: { onAuthenticated: () => Promise<
           disabled={loading}
           data-testid="login-mfa-submit"
         >
-          {loading ? "Verifying…" : "Verify"}
+          {loading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Verifying…
+            </>
+          ) : (
+            "Verify"
+          )}
         </Button>
       </form>
     );
@@ -242,7 +249,14 @@ export function SignInTab({ onAuthenticated }: { onAuthenticated: () => Promise<
         disabled={loading}
         data-testid="login-signin-submit"
       >
-        {loading ? "Signing in…" : "Sign in"}
+        {loading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Signing in…
+          </>
+        ) : (
+          "Sign in"
+        )}
       </Button>
       <p className="text-center text-sm">
         <a

--- a/packages/client/src/components/auth/SignUpTab.tsx
+++ b/packages/client/src/components/auth/SignUpTab.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthFieldError } from "@/components/auth/AuthFieldError";
-import { AlertCircle, Eye, EyeOff } from "lucide-react";
+import { AlertCircle, Eye, EyeOff, Loader2 } from "lucide-react";
 
 function getPasswordStrength(password: string): { score: number; label: string; color: string } {
   let score = 0;
@@ -73,13 +73,15 @@ export function SignUpTab({ onAuthenticated }: { onAuthenticated: () => Promise<
 
   return (
     <>
-      <SetupStepIndicator
-        steps={[
-          { label: "Create Account", completed: false, active: true },
-          { label: "Configure Server", completed: false, active: false },
-          { label: "Deploy", completed: false, active: false }
-        ]}
-      />
+      {!feedback && (
+        <SetupStepIndicator
+          steps={[
+            { label: "Create Account", completed: false, active: true },
+            { label: "Configure Server", completed: false, active: false },
+            { label: "Deploy", completed: false, active: false }
+          ]}
+        />
+      )}
       <form className="mt-4 flex flex-col gap-4" noValidate onSubmit={(e) => void handleSubmit(e)}>
         <div className="space-y-2">
           <Label htmlFor="signup-name">Name</Label>
@@ -184,7 +186,14 @@ export function SignUpTab({ onAuthenticated }: { onAuthenticated: () => Promise<
           disabled={loading}
           data-testid="login-signup-submit"
         >
-          {loading ? "Creating account…" : "Create account"}
+          {loading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Creating account…
+            </>
+          ) : (
+            "Create account"
+          )}
         </Button>
       </form>
     </>

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -477,6 +477,80 @@ body:is(.dark *)::after {
   margin: 0;
 }
 
+/* ========= Sidebar nav groups ========= */
+.sidebar__group-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  appearance: none;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  margin: 0.75rem 0 0.25rem;
+  padding: 0 0.45rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--sidebar-accent-foreground);
+  white-space: nowrap;
+  overflow: hidden;
+  min-height: 1.1rem;
+  transition: color 0.15s;
+}
+
+.sidebar__group-toggle:hover {
+  color: var(--sidebar-foreground);
+}
+
+.sidebar__group-toggle svg {
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.sidebar__group-toggle[data-open="true"] svg {
+  transform: rotate(0deg);
+}
+
+.sidebar__group-toggle[data-open="false"] svg {
+  transform: rotate(-90deg);
+}
+
+.sidebar__group-items {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 0.2s ease;
+}
+
+.sidebar__group-items[data-open="false"] {
+  grid-template-rows: 0fr;
+}
+
+.sidebar__group-items-inner {
+  overflow: hidden;
+}
+
+/* ========= Mobile sidebar ========= */
+.mobile-menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--foreground);
+  cursor: pointer;
+  padding: 0.35rem;
+  margin-right: 0.5rem;
+  flex-shrink: 0;
+}
+
+.mobile-backdrop {
+  display: none;
+}
+
 /* ========= Responsive ========= */
 @media (max-width: 900px) {
   .layout {
@@ -489,6 +563,27 @@ body:is(.dark *)::after {
     left: calc(-1 * var(--layout-sidebar-mobile-width));
     width: var(--layout-sidebar-mobile-width);
     z-index: 200;
+  }
+
+  .sidebar[data-mobile-open="true"] {
+    left: 0;
+  }
+
+  .mobile-menu-btn {
+    display: flex;
+  }
+
+  .mobile-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 199;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+  }
+
+  .mobile-backdrop[data-open="true"] {
+    display: block;
   }
 
   .shell {

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -525,6 +525,7 @@ body:is(.dark *)::after {
 
 .sidebar__group-items[data-open="false"] {
   grid-template-rows: 0fr;
+  visibility: hidden;
 }
 
 .sidebar__group-items-inner {

--- a/packages/client/src/layouts/DashboardLayout.tsx
+++ b/packages/client/src/layouts/DashboardLayout.tsx
@@ -1,50 +1,16 @@
 import { useEffect, useState } from "react";
 import { NavLink, Navigate, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { ErrorBoundary } from "../components/ErrorBoundary";
-import { useTheme } from "../components/theme-context";
-import { useSession, authClient } from "../lib/auth-client";
+import { useSession } from "../lib/auth-client";
 import { Separator } from "@/components/ui/separator";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { KeyboardShortcutsDialog } from "@/components/KeyboardShortcutsDialog";
 import { CommandPalette } from "@/components/CommandPalette";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from "@/components/ui/dropdown-menu";
-import {
-  ChevronLeft,
-  ChevronRight,
-  ChevronDown,
-  LogOut,
-  User,
-  ChevronsUpDown,
-  Hexagon,
-  Sun,
-  Moon,
-  Menu
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronDown, Hexagon, Menu } from "lucide-react";
 import { homeNavGroups, settingsNav } from "./sidebar-nav";
-
-const ID_SEGMENT_RE = /^[0-9a-f]{9,}$|^[0-9a-f-]{20,}$/i;
-
-function formatSegment(s: string): string {
-  if (ID_SEGMENT_RE.test(s)) return s.slice(0, 8) + "…";
-  return s
-    .split("-")
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
-}
-
-function breadcrumbFromPath(pathname: string): string[] {
-  if (pathname === "/") return ["Dashboard"];
-  return pathname.split("/").filter(Boolean).map(formatSegment);
-}
+import { breadcrumbFromPath } from "./dashboard-breadcrumb";
+import { SidebarFooter } from "./SidebarFooter";
 
 export function DashboardLayout() {
   const session = useSession();
@@ -52,7 +18,6 @@ export function DashboardLayout() {
   const navigate = useNavigate();
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const themeCtx = useTheme();
   const crumbs = breadcrumbFromPath(location.pathname);
 
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
@@ -114,8 +79,6 @@ export function DashboardLayout() {
     return <Navigate to={`/login?returnTo=${encodeURIComponent(returnTo)}`} replace />;
   }
 
-  const userInitial = session.data.user.name?.charAt(0).toUpperCase() ?? "U";
-
   function isSettingsItemActive(tab: string | null) {
     if (location.pathname !== "/settings") {
       return false;
@@ -167,11 +130,10 @@ export function DashboardLayout() {
                 const isOpen = openGroups[group.key] !== false;
                 return (
                   <div key={group.key}>
-                    {collapsed ? (
-                      <p className="sidebar__group-label" />
-                    ) : (
+                    {!collapsed && (
                       <button
                         className="sidebar__group-toggle"
+                        aria-expanded={isOpen}
                         data-open={isOpen ? "true" : "false"}
                         onClick={() => toggleGroup(group.key)}
                       >
@@ -241,79 +203,11 @@ export function DashboardLayout() {
             </nav>
           </TooltipProvider>
 
-          <TooltipProvider delay={0}>
-            <div className="sidebar__footer">
-              {(() => {
-                const btn = (
-                  <button
-                    className="sidebar__link"
-                    onClick={() => {
-                      const { resolved, setTheme } = themeCtx;
-                      setTheme(resolved === "dark" ? "light" : "dark");
-                    }}
-                  >
-                    {themeCtx.resolved === "dark" ? (
-                      <Sun size={18} className="sidebar__link-icon" />
-                    ) : (
-                      <Moon size={18} className="sidebar__link-icon" />
-                    )}
-                    {!collapsed && (
-                      <span>{themeCtx.resolved === "dark" ? "Light mode" : "Dark mode"}</span>
-                    )}
-                  </button>
-                );
-                return collapsed ? (
-                  <Tooltip>
-                    <TooltipTrigger render={btn} />
-                    <TooltipContent side="right">Toggle theme</TooltipContent>
-                  </Tooltip>
-                ) : (
-                  btn
-                );
-              })()}
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <button className="sidebar__user-card group">
-                      <Avatar className="h-8 w-8 ring-2 ring-transparent transition-all group-hover:ring-primary/20">
-                        <AvatarFallback className="bg-primary/10 text-xs font-semibold text-primary">
-                          {userInitial}
-                        </AvatarFallback>
-                      </Avatar>
-                      {!collapsed && (
-                        <>
-                          <div className="sidebar__user-info">
-                            <p className="sidebar__user-name">{session.data.user.name}</p>
-                            <p className="sidebar__user-email">{session.data.user.email}</p>
-                          </div>
-                          <ChevronsUpDown size={14} className="ml-auto opacity-50" />
-                        </>
-                      )}
-                    </button>
-                  }
-                />
-                <DropdownMenuContent side="top" className="w-56 backdrop-blur-xl" align="start">
-                  <DropdownMenuLabel>
-                    <p className="font-medium">{session.data.user.name}</p>
-                    <p className="text-xs text-muted-foreground">{session.data.user.email}</p>
-                  </DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => void navigate("/profile")}>
-                    <User size={14} />
-                    Profile Settings
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => void authClient.signOut()}
-                    className="text-destructive"
-                  >
-                    <LogOut size={14} />
-                    Sign out
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </TooltipProvider>
+          <SidebarFooter
+            collapsed={collapsed}
+            userName={session.data.user.name ?? ""}
+            userEmail={session.data.user.email}
+          />
         </aside>
 
         {/* ── Main content ── */}
@@ -328,24 +222,18 @@ export function DashboardLayout() {
             </button>
             <nav className="topbar__breadcrumb" aria-label="Breadcrumb">
               {crumbs.map((crumb, i) => {
-                const path =
-                  "/" +
-                  crumbs
-                    .slice(0, i + 1)
-                    .map((c) => c.toLowerCase())
-                    .join("/");
                 const isLast = i === crumbs.length - 1;
                 return (
-                  <span key={crumb}>
+                  <span key={crumb.path}>
                     {i > 0 && <span className="topbar__breadcrumb-sep">/</span>}
                     {isLast ? (
-                      <span className="topbar__breadcrumb-current">{crumb}</span>
+                      <span className="topbar__breadcrumb-current">{crumb.label}</span>
                     ) : (
                       <button
                         className="topbar__breadcrumb-item hover:underline"
-                        onClick={() => void navigate(path === "/dashboard" ? "/" : path)}
+                        onClick={() => void navigate(crumb.path)}
                       >
-                        {crumb}
+                        {crumb.label}
                       </button>
                     )}
                   </span>

--- a/packages/client/src/layouts/DashboardLayout.tsx
+++ b/packages/client/src/layouts/DashboardLayout.tsx
@@ -18,62 +18,32 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import {
-  LayoutDashboard,
-  FolderKanban,
-  Server,
-  Rocket,
-  DatabaseBackup,
-  CalendarClock,
-  Settings,
   ChevronLeft,
   ChevronRight,
+  ChevronDown,
   LogOut,
   User,
-  Shield,
-  KeyRound,
-  Bell,
-  HardDrive,
   ChevronsUpDown,
   Hexagon,
-  Bot,
-  Workflow,
-  Radio,
   Sun,
   Moon,
-  ShieldCheck,
-  ScrollText
+  Menu
 } from "lucide-react";
+import { homeNavGroups, settingsNav } from "./sidebar-nav";
 
-const homeNav = [
-  { to: "/", label: "Dashboard", icon: LayoutDashboard, end: true },
-  { to: "/projects", label: "Projects", icon: FolderKanban },
-  { to: "/deploy", label: "Deploy", icon: Rocket },
-  { to: "/servers", label: "Servers", icon: Server },
-  { to: "/deployments", label: "Deployments", icon: Rocket },
-  { to: "/backups", label: "Backups", icon: DatabaseBackup },
-  { to: "/schedules", label: "Schedules", icon: CalendarClock },
-  { to: "/destinations", label: "Destinations", icon: HardDrive },
-  { to: "/notifications", label: "Notifications", icon: Radio },
-  { to: "/agents", label: "Agents", icon: Bot },
-  { to: "/development-tasks", label: "Dev Tasks", icon: Workflow },
-  { to: "/approvals", label: "Approvals", icon: ShieldCheck },
-  { to: "/requests", label: "Requests", icon: ScrollText }
-] as const;
+const ID_SEGMENT_RE = /^[0-9a-f]{9,}$|^[0-9a-f-]{20,}$|.*[_-].*\d{2,}/i;
 
-const settingsNav = [
-  { to: "/settings", label: "General", icon: Settings, tab: null },
-  { to: "/settings?tab=users", label: "Users", icon: User, tab: "users" },
-  { to: "/settings?tab=tokens", label: "Tokens", icon: KeyRound, tab: "tokens" },
-  { to: "/settings?tab=security", label: "Security", icon: Shield, tab: "security" },
-  { to: "/settings?tab=notifications", label: "Notifications", icon: Bell, tab: "notifications" }
-] as const;
+function formatSegment(s: string): string {
+  if (ID_SEGMENT_RE.test(s)) return s.slice(0, 8) + "…";
+  return s
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
 
 function breadcrumbFromPath(pathname: string): string[] {
   if (pathname === "/") return ["Dashboard"];
-  return pathname
-    .split("/")
-    .filter(Boolean)
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1));
+  return pathname.split("/").filter(Boolean).map(formatSegment);
 }
 
 export function DashboardLayout() {
@@ -81,10 +51,33 @@ export function DashboardLayout() {
   const location = useLocation();
   const navigate = useNavigate();
   const [collapsed, setCollapsed] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
   const themeCtx = useTheme();
   const crumbs = breadcrumbFromPath(location.pathname);
 
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
+    try {
+      const stored = localStorage.getItem("df-sidebar-groups");
+      if (stored) return JSON.parse(stored) as Record<string, boolean>;
+    } catch {
+      /* ignore */
+    }
+    return Object.fromEntries(homeNavGroups.map((g) => [g.key, true]));
+  });
+
+  const toggleGroup = (key: string) => {
+    setOpenGroups((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      localStorage.setItem("df-sidebar-groups", JSON.stringify(next));
+      return next;
+    });
+  };
+
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [location.pathname, location.search]);
 
   useEffect(() => {
     const handleOnline = () => setIsOffline(false);
@@ -137,8 +130,13 @@ export function DashboardLayout() {
         Skip to content
       </a>
       <div className="layout" data-collapsed={collapsed ? "true" : "false"}>
+        <div
+          className="mobile-backdrop"
+          data-open={mobileOpen ? "true" : "false"}
+          onClick={() => setMobileOpen(false)}
+        />
         {/* ── Sidebar ── */}
-        <aside className="sidebar">
+        <aside className="sidebar" data-mobile-open={mobileOpen ? "true" : "false"}>
           <div className="sidebar__brand">
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10">
               <Hexagon size={18} strokeWidth={1.5} className="text-primary" />
@@ -156,28 +154,53 @@ export function DashboardLayout() {
 
           <TooltipProvider delay={0}>
             <nav className="sidebar__nav">
-              <p className="sidebar__group-label">{!collapsed && "Home"}</p>
-              {homeNav.map((item) => {
-                const link = (
-                  <NavLink
-                    key={item.to}
-                    to={item.to}
-                    end={"end" in item ? item.end : false}
-                    className={({ isActive }) =>
-                      `sidebar__link${isActive ? " sidebar__link--active" : ""}`
-                    }
-                  >
-                    <item.icon size={18} className="sidebar__link-icon" />
-                    {!collapsed && <span>{item.label}</span>}
-                  </NavLink>
-                );
-                return collapsed ? (
-                  <Tooltip key={item.to}>
-                    <TooltipTrigger render={link} />
-                    <TooltipContent side="right">{item.label}</TooltipContent>
-                  </Tooltip>
-                ) : (
-                  link
+              {homeNavGroups.map((group) => {
+                const isOpen = openGroups[group.key] !== false;
+                return (
+                  <div key={group.key}>
+                    {collapsed ? (
+                      <p className="sidebar__group-label" />
+                    ) : (
+                      <button
+                        className="sidebar__group-toggle"
+                        data-open={isOpen ? "true" : "false"}
+                        onClick={() => toggleGroup(group.key)}
+                      >
+                        {group.label}
+                        <ChevronDown size={12} />
+                      </button>
+                    )}
+                    <div
+                      className="sidebar__group-items"
+                      data-open={collapsed || isOpen ? "true" : "false"}
+                    >
+                      <div className="sidebar__group-items-inner">
+                        {group.items.map((item) => {
+                          const link = (
+                            <NavLink
+                              key={item.to}
+                              to={item.to}
+                              end={item.end ?? false}
+                              className={({ isActive }) =>
+                                `sidebar__link${isActive ? " sidebar__link--active" : ""}`
+                              }
+                            >
+                              <item.icon size={18} className="sidebar__link-icon" />
+                              {!collapsed && <span>{item.label}</span>}
+                            </NavLink>
+                          );
+                          return collapsed ? (
+                            <Tooltip key={item.to}>
+                              <TooltipTrigger render={link} />
+                              <TooltipContent side="right">{item.label}</TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            link
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
                 );
               })}
 
@@ -287,6 +310,13 @@ export function DashboardLayout() {
         {/* ── Main content ── */}
         <section className="layout__content">
           <header className="topbar" role="banner">
+            <button
+              className="mobile-menu-btn"
+              onClick={() => setMobileOpen((v) => !v)}
+              aria-label="Toggle menu"
+            >
+              <Menu size={20} />
+            </button>
             <nav className="topbar__breadcrumb" aria-label="Breadcrumb">
               {crumbs.map((crumb, i) => {
                 const path =

--- a/packages/client/src/layouts/DashboardLayout.tsx
+++ b/packages/client/src/layouts/DashboardLayout.tsx
@@ -31,7 +31,7 @@ import {
 } from "lucide-react";
 import { homeNavGroups, settingsNav } from "./sidebar-nav";
 
-const ID_SEGMENT_RE = /^[0-9a-f]{9,}$|^[0-9a-f-]{20,}$|.*[_-].*\d{2,}/i;
+const ID_SEGMENT_RE = /^[0-9a-f]{9,}$|^[0-9a-f-]{20,}$/i;
 
 function formatSegment(s: string): string {
   if (ID_SEGMENT_RE.test(s)) return s.slice(0, 8) + "…";
@@ -89,6 +89,15 @@ export function DashboardLayout() {
       window.removeEventListener("offline", handleOffline);
     };
   }, []);
+
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileOpen(false);
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [mobileOpen]);
 
   // Loading state
   if (session.isPending) {

--- a/packages/client/src/layouts/SidebarFooter.tsx
+++ b/packages/client/src/layouts/SidebarFooter.tsx
@@ -90,7 +90,11 @@ export function SidebarFooter({
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              onClick={() => void authClient.signOut()}
+              onClick={() => {
+                authClient.signOut().catch((err: unknown) => {
+                  console.error("Sign-out failed", err);
+                });
+              }}
               className="text-destructive"
             >
               <LogOut size={14} />

--- a/packages/client/src/layouts/SidebarFooter.tsx
+++ b/packages/client/src/layouts/SidebarFooter.tsx
@@ -1,0 +1,104 @@
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "../components/theme-context";
+import { authClient } from "../lib/auth-client";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+import { LogOut, User, ChevronsUpDown, Sun, Moon } from "lucide-react";
+
+export function SidebarFooter({
+  collapsed,
+  userName,
+  userEmail
+}: {
+  collapsed: boolean;
+  userName: string;
+  userEmail: string;
+}) {
+  const navigate = useNavigate();
+  const themeCtx = useTheme();
+  const userInitial = userName?.charAt(0).toUpperCase() ?? "U";
+
+  return (
+    <TooltipProvider delay={0}>
+      <div className="sidebar__footer">
+        {(() => {
+          const btn = (
+            <button
+              className="sidebar__link"
+              onClick={() => {
+                const { resolved, setTheme } = themeCtx;
+                setTheme(resolved === "dark" ? "light" : "dark");
+              }}
+            >
+              {themeCtx.resolved === "dark" ? (
+                <Sun size={18} className="sidebar__link-icon" />
+              ) : (
+                <Moon size={18} className="sidebar__link-icon" />
+              )}
+              {!collapsed && (
+                <span>{themeCtx.resolved === "dark" ? "Light mode" : "Dark mode"}</span>
+              )}
+            </button>
+          );
+          return collapsed ? (
+            <Tooltip>
+              <TooltipTrigger render={btn} />
+              <TooltipContent side="right">Toggle theme</TooltipContent>
+            </Tooltip>
+          ) : (
+            btn
+          );
+        })()}
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={
+              <button className="sidebar__user-card group">
+                <Avatar className="h-8 w-8 ring-2 ring-transparent transition-all group-hover:ring-primary/20">
+                  <AvatarFallback className="bg-primary/10 text-xs font-semibold text-primary">
+                    {userInitial}
+                  </AvatarFallback>
+                </Avatar>
+                {!collapsed && (
+                  <>
+                    <div className="sidebar__user-info">
+                      <p className="sidebar__user-name">{userName}</p>
+                      <p className="sidebar__user-email">{userEmail}</p>
+                    </div>
+                    <ChevronsUpDown size={14} className="ml-auto opacity-50" />
+                  </>
+                )}
+              </button>
+            }
+          />
+          <DropdownMenuContent side="top" className="w-56 backdrop-blur-xl" align="start">
+            <DropdownMenuLabel>
+              <p className="font-medium">{userName}</p>
+              <p className="text-xs text-muted-foreground">{userEmail}</p>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => void navigate("/profile")}>
+              <User size={14} />
+              Profile Settings
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => void authClient.signOut()}
+              className="text-destructive"
+            >
+              <LogOut size={14} />
+              Sign out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/packages/client/src/layouts/dashboard-breadcrumb.ts
+++ b/packages/client/src/layouts/dashboard-breadcrumb.ts
@@ -1,4 +1,5 @@
-const ID_SEGMENT_RE = /^[0-9a-f]{9,}$|^[0-9a-f-]{20,}$/i;
+const ID_SEGMENT_RE =
+  /^[0-9a-f]{9,}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function formatSegment(s: string): string {
   if (ID_SEGMENT_RE.test(s)) return s.slice(0, 8) + "…";

--- a/packages/client/src/layouts/dashboard-breadcrumb.ts
+++ b/packages/client/src/layouts/dashboard-breadcrumb.ts
@@ -1,0 +1,23 @@
+const ID_SEGMENT_RE = /^[0-9a-f]{9,}$|^[0-9a-f-]{20,}$/i;
+
+function formatSegment(s: string): string {
+  if (ID_SEGMENT_RE.test(s)) return s.slice(0, 8) + "…";
+  return s
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export interface Breadcrumb {
+  label: string;
+  path: string;
+}
+
+export function breadcrumbFromPath(pathname: string): Breadcrumb[] {
+  if (pathname === "/") return [{ label: "Dashboard", path: "/" }];
+  const segments = pathname.split("/").filter(Boolean);
+  return segments.map((s, i) => {
+    const path = "/" + segments.slice(0, i + 1).join("/");
+    return { label: formatSegment(s), path: path === "/dashboard" ? "/" : path };
+  });
+}

--- a/packages/client/src/layouts/sidebar-nav.ts
+++ b/packages/client/src/layouts/sidebar-nav.ts
@@ -1,0 +1,97 @@
+import {
+  LayoutDashboard,
+  FolderKanban,
+  Server,
+  Rocket,
+  DatabaseBackup,
+  CalendarClock,
+  Settings,
+  User,
+  Shield,
+  KeyRound,
+  Bell,
+  HardDrive,
+  Bot,
+  Workflow,
+  Radio,
+  ShieldCheck,
+  ScrollText,
+  Upload,
+  Wrench,
+  Boxes,
+  GitBranch,
+  Lock
+} from "lucide-react";
+
+export interface NavItem {
+  to: string;
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  end?: boolean;
+}
+
+export interface NavGroup {
+  key: string;
+  label: string;
+  items: NavItem[];
+}
+
+export interface SettingsNavItem {
+  to: string;
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  tab: string | null;
+}
+
+export const homeNavGroups: NavGroup[] = [
+  {
+    key: "core",
+    label: "Core",
+    items: [
+      { to: "/", label: "Dashboard", icon: LayoutDashboard, end: true },
+      { to: "/projects", label: "Projects", icon: FolderKanban },
+      { to: "/deploy", label: "Deploy", icon: Upload },
+      { to: "/servers", label: "Servers", icon: Server }
+    ]
+  },
+  {
+    key: "operations",
+    label: "Operations",
+    items: [
+      { to: "/deployments", label: "Deployments", icon: Rocket },
+      { to: "/backups", label: "Backups", icon: DatabaseBackup },
+      { to: "/schedules", label: "Schedules", icon: CalendarClock },
+      { to: "/destinations", label: "Destinations", icon: HardDrive }
+    ]
+  },
+  {
+    key: "automation",
+    label: "Automation",
+    items: [
+      { to: "/agents", label: "Agents", icon: Bot },
+      { to: "/development-tasks", label: "Dev Tasks", icon: Workflow },
+      { to: "/approvals", label: "Approvals", icon: ShieldCheck }
+    ]
+  },
+  {
+    key: "monitoring",
+    label: "Monitoring",
+    items: [
+      { to: "/notifications", label: "Notifications", icon: Radio },
+      { to: "/requests", label: "Requests", icon: ScrollText }
+    ]
+  }
+];
+
+export const settingsNav: SettingsNavItem[] = [
+  { to: "/settings", label: "General", icon: Settings, tab: null },
+  { to: "/settings?tab=users", label: "Users", icon: User, tab: "users" },
+  { to: "/settings?tab=tokens", label: "Tokens", icon: KeyRound, tab: "tokens" },
+  { to: "/settings?tab=security", label: "Security", icon: Shield, tab: "security" },
+  { to: "/settings?tab=notifications", label: "Notifications", icon: Bell, tab: "notifications" },
+  { to: "/settings?tab=volumes", label: "Volumes", icon: HardDrive, tab: "volumes" },
+  { to: "/settings?tab=operations", label: "Operations", icon: Wrench, tab: "operations" },
+  { to: "/settings?tab=registries", label: "Registries", icon: Boxes, tab: "registries" },
+  { to: "/settings?tab=git", label: "Git", icon: GitBranch, tab: "git" },
+  { to: "/settings?tab=secrets", label: "Secrets", icon: Lock, tab: "secrets" }
+];


### PR DESCRIPTION
## Summary

- **Mobile hamburger menu**: Sidebar now has a slide-in toggle with backdrop overlay on screens < 900px — previously navigation was inaccessible on mobile/tablet
- **Sidebar grouping**: 13 flat nav items organized into 4 collapsible groups (Core, Operations, Automation, Monitoring) with localStorage persistence
- **Settings nav reconciliation**: Sidebar now shows all 10 settings tabs (was only showing 5 — volumes, operations, registries, git, secrets were hidden)
- **Duplicate icon fix**: Deploy now uses `Upload` icon instead of `Rocket` (which is used by Deployments)
- **Breadcrumb improvement**: ID/UUID segments are truncated to 8 chars with ellipsis; hyphenated segments properly title-cased
- **Login loading spinners**: Sign In and Sign Up buttons show `Loader2` spinner during API calls
- **Stepper visibility**: Setup stepper hides on signup error, reappears when user corrects input

## Test plan

- [ ] Verify sidebar renders 4 collapsible groups with correct items
- [ ] Verify group collapse state persists across page refreshes (localStorage)
- [ ] Resize browser below 900px — hamburger menu should appear in topbar
- [ ] Click hamburger — sidebar slides in with backdrop; click backdrop or nav link to close
- [ ] Navigate to /settings — all 10 tabs should appear in sidebar
- [ ] Check breadcrumbs on /projects/{id} — ID should be truncated
- [ ] Sign in with wrong password — button should show spinner then error
- [ ] Sign up with invalid data — stepper should hide on error
- [ ] All 162 client unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible, grouped sidebar with persistent open/closed state
  * Mobile sidebar with backdrop, toggle button and Escape-to-close behavior
  * Sidebar footer with theme toggle and user menu (profile & sign out)
  * Enhanced loading indicators (spinner + descriptive text) for sign-in/sign-up flows
  * Sidebar navigation data and breadcrumb generation extracted to reusable modules

* **Style**
  * Updated sidebar and mobile styles for smoother expand/collapse and overlays

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaoFlow-dev/DaoFlow/pull/205)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->