### PR TITLE
fix(audit,observability): link diagnosis to real evidence IDs, audit managed DB creation, document gaps

### DIFF
--- a/.agents/references/e2e-coverage-and-real-infra.md
+++ b/.agents/references/e2e-coverage-and-real-infra.md
@@ -1,0 +1,91 @@
+# E2E Coverage and Real-Infra Validation
+
+This reference records, honestly, how much of DaoFlow's deployment execution path
+the automated test suite actually exercises — and what it does **not**. Green CI
+should never be mistaken for proof that real deployments work.
+
+## Current reality
+
+There are two distinct E2E jobs in `.github/workflows/ci.yml`:
+
+### 1. Main E2E suite — execution plane is MOCKED
+
+- Runs with `DISABLE_WORKER=true` (see `packages/server/src/index.ts`,
+  `shouldStartWorker()`).
+- With the worker disabled, no SSH connection and no `docker`/`docker compose`
+  process is ever spawned.
+- Deployment specs (e.g. `e2e/deployments.spec.ts`) drive state transitions by
+  calling `triggerDeploy` → `dispatchExecutionJob` → `completeExecutionJob`
+  directly. The "healthy" assertion checks **database state**, not a real
+  container.
+- This suite validates the control plane: API contracts, RBAC, UI rendering,
+  audit/event records, deployment bookkeeping. That is genuinely valuable — but it
+  is white-box mocking of the execution plane.
+
+### 2. `e2e-worker` job — execution plane is REAL, but narrow
+
+- Runs with the worker enabled and `DAOFLOW_ENABLE_TEMPORAL=true`.
+- `e2e/workflow-e2e.spec.ts` runs a real Temporal workflow that spawns the real
+  `docker` CLI via `packages/server/src/worker/docker-executor.ts`.
+- **Limitations:**
+  - Targets `localhost` only — the **remote SSH path is never exercised in CI**.
+    `packages/server/src/worker/ssh-connection.ts` (`execRemote`, real `ssh`
+    spawn) has unit coverage with a mocked `execImpl`, but no end-to-end run
+    against a real remote host.
+  - Happy-path only — no failure injection (SSH auth failure, Docker daemon
+    down, mid-deploy crash, network partition).
+  - No backup→restore round-trip against real storage.
+  - No rollback-to-prior-deployment against a real running stack.
+
+## The honest gap
+
+| Path                                                    | Covered in CI?                   |
+| ------------------------------------------------------- | -------------------------------- |
+| Control-plane logic, RBAC, audit, UI                    | Yes (main E2E)                   |
+| Local Docker deploy happy path                          | Yes (`e2e-worker`)               |
+| **Remote SSH deploy**                                   | **No**                           |
+| **Deploy failure / rollback against real stack**        | **No**                           |
+| **Backup + restore round-trip against real storage**    | **No**                           |
+| **50-concurrent-deploy state-integrity (roadmap #173)** | **No (not against real Docker)** |
+
+Charter §20 defines success as "the one a small team can trust to run production
+workloads." None of the rows marked **No** above are currently proven.
+
+## Injection seam (for building a real-infra harness)
+
+The execution layer does **not** use a DI framework. Production code imports the
+SSH/Docker modules directly; unit tests swap them with `vi.mock()` (which does not
+work in Playwright). The local-vs-remote branch is:
+
+- `packages/server/src/worker/execution-target.ts` — `resolveExecutionTarget()`
+  returns `{ mode: "local" }` for localhost or `{ mode: "remote", ssh, ... }`.
+- `packages/server/src/worker/compose-deploy-operations.ts` — switches between
+  `dockerStackRemove` (local) and `remoteDockerStackRemove` (SSH) on `target.mode`.
+
+To validate the remote path without a refactor, the cheapest approach is a real
+SSH target rather than a code seam: bring up an SSH-reachable Docker host (a
+sibling container running `sshd` + Docker, or a throwaway VPS) and register it as
+a `remote` server.
+
+## Proposed real-infra harness (opt-in, not in default CI gate)
+
+A new Playwright project, **skipped unless `DAOFLOW_REAL_INFRA=1`**, that runs the
+full lifecycle against a real remote-style target:
+
+1. Provision an SSH-reachable Docker host (compose sidecar `sshd`+`dind`, or a
+   tagged ephemeral VPS).
+2. Register it as a `remote` server; assert SSH connectivity check passes.
+3. Deploy a real compose stack; assert the container is actually running
+   (`docker compose ps` over SSH), not just a DB row.
+4. Inject a failure (bad image tag); assert structured failure analysis and that
+   `daoflow diagnose` cites real log/event IDs.
+5. Roll back to the prior deployment record; assert the previous container is
+   restored.
+6. Register a volume, run a backup to MinIO (S3-compatible), restore it, and
+   verify data integrity.
+7. Run the concurrency stress (roadmap #173) against real Docker.
+
+This harness is intentionally **out of the required PR gate** (it needs real
+infra and is slow). It should run nightly and pre-release. Until it exists and is
+green, treat remote deploy, rollback, and backup/restore as **unverified against
+real infrastructure**.

--- a/.agents/roadmaps/e2e-implementation-roadmap.md
+++ b/.agents/roadmaps/e2e-implementation-roadmap.md
@@ -232,3 +232,54 @@ Detailed tasks are grouped by milestone. Each task should be independently testa
 176. CLI `--help` output documents required scopes for every command
 177. OpenAPI-compatible schema generated from tRPC for external documentation
 178. Production release workflow publishes a shadow Docker Hub image to `daoflow/daoflow` using the already-configured `DOCKER_HUB_TOKEN` GitHub Actions secret
+
+## 1.0 Exit Criteria
+
+Every milestone above is implemented in code. "Implemented" is not "trustworthy."
+Per charter §20, the bar for 1.0 is: _a small team can trust DaoFlow to run
+production workloads on their own servers._ The 15-milestone checklist does not
+prove that. 1.0 ships only when all of the following are true:
+
+1. **Real-infra lifecycle proven.** The full loop — deploy a real Compose stack
+   over SSH to a real remote host, fail it, roll back to a prior deployment
+   record, back a volume up to S3-compatible storage, and restore it with verified
+   data integrity — runs green in an opt-in harness (`DAOFLOW_REAL_INFRA=1`). See
+   [e2e-coverage-and-real-infra.md](../references/e2e-coverage-and-real-infra.md).
+   Today the main E2E suite mocks the execution plane (`DISABLE_WORKER=true`) and
+   the only real run is localhost happy-path.
+2. **Agent loop proven.** An LLM driving DaoFlow purely through the CLI/API can
+   deploy, diagnose a real failure (with diagnosis citing real log/event IDs), and
+   propose a rollback — and provably cannot perform any mutation outside its
+   granted scopes. This is the product thesis; nothing else validates it.
+3. **Audit completeness.** Every command-lane mutation provably emits an
+   `audit_entry`, enforced by a test, not by reviewer vigilance.
+4. **No feature masquerades as working when it is stale or stubbed.** Specifically,
+   `daoflow drift` must either compute live drift or clearly mark its output as a
+   cached snapshot (see Known Gaps).
+5. **Quickstart verified by a stranger.** Someone who did not build DaoFlow goes
+   from clone to a deployed, backed-up production service in under 30 minutes
+   following only the README.
+
+Until #1 and #2 are green, prefer hardening the standalone Docker/Compose path
+over any scope expansion (Swarm, autonomous code-writing agents).
+
+## Known Gaps
+
+These are implemented-but-shallow or stubbed surfaces. Documented here so they are
+not mistaken for finished work.
+
+- **`daoflow drift` is not live (STUB).** `listComposeDriftReport`
+  (`packages/server/src/db/services/compose.ts`) only reads pre-computed reports
+  from `environment.config.composeDriftReports`. Nothing populates that array from
+  the running server, so drift output is empty or stale and currently presents as
+  authoritative. Fix: a `computeComposeDriftReport(environment, server)` that SSHes
+  to the target, runs `docker compose ps` / `docker inspect`, and diffs desired vs
+  actual (image refs, replica counts, container state). Interim safety: surface a
+  `dataSource: "cached-snapshot"` / `live: false` flag so consumers and agents are
+  not misled.
+- **Remote-SSH deploy, rollback, and backup/restore are unverified against real
+  infrastructure.** See the coverage reference above.
+- **Audit logging is ad-hoc, not enforced.** There is no central middleware and no
+  test asserting coverage. `createManagedDatabase` was missing a top-level audit
+  entry (now fixed). Add a coverage-enforcing test over the command router so new
+  mutations cannot ship unaudited.

--- a/.agents/roadmaps/swarm-post-mvp-roadmap.md
+++ b/.agents/roadmaps/swarm-post-mvp-roadmap.md
@@ -19,14 +19,20 @@ DaoFlow does **not** yet ship cluster-aware execution semantics:
 
 ## Release Slices
 
+> Note: earlier drafts cited GitHub issues `#108` and `#110` for these slices.
+> Those issues do not exist in this repository. Do not begin a slice until its
+> tracking issue is actually filed and linked here. Per charter §3, Swarm work
+> must not begin until the standalone Docker/Compose path is proven solid in
+> production — see the 1.0 exit criteria in `e2e-implementation-roadmap.md`.
+
 1. Swarm execution and rollback semantics
-   - GitHub issue: `#108`
+   - Tracking issue: not yet filed.
    - branch deployment planning by target kind
    - add `docker stack deploy` / rollback execution with auditable step models
    - preserve standalone Docker behavior without regression
 
 2. Operator and agent affordances
-   - GitHub issue: `#110`
+   - Tracking issue: not yet filed.
    - expose Swarm-specific deploy and rollback previews in CLI and UI
    - gate mutations behind explicit scopes and approval language
    - document coexistence and failure recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+All notable changes to DaoFlow are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This file was reconstructed from the git tag history (`v0.5.x` – `v0.9.2`). Entries
+predating this reconstruction are summarized at the release level rather than
+per-commit. Going forward, update this file in the same PR as the change.
+
+## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md` and an explicit **1.0 exit criteria** section in the e2e roadmap.
+- `.agents/references/e2e-coverage-and-real-infra.md` documenting exactly which
+  parts of the test suite exercise real Docker/SSH versus mocked execution, and a
+  design for a real-infra validation harness.
+- Top-level audit entry for `managed_database.create` so managed-database
+  provisioning is auditable as a single operation (charter §14).
+
+### Changed
+
+- Deployment watchdog diagnosis now links its evidence to the exact persisted
+  `events` and `deployment_logs` row IDs instead of an opaque static identifier
+  (charter §10: "any AI-generated diagnosis must link back to exact log lines or
+  event IDs").
+
+### Known gaps (documented, not yet fixed)
+
+- **Config drift (`daoflow drift`) is not live.** It reads pre-computed reports
+  from `environment.config.composeDriftReports`; nothing currently populates them
+  from the running server. See the e2e roadmap "Known Gaps" section.
+- **Main E2E suite mocks the execution plane** (`DISABLE_WORKER=true`). Only the
+  separate `e2e-worker` job exercises real Docker, and only against localhost. See
+  the real-infra coverage reference above.
+
+## [0.9.2] - 2026-05-14
+
+### Fixed
+
+- Bun baseline segfault in E2E CI.
+
+## [0.9.1] - 2026-05-14
+
+### Added
+
+- SSRF protection.
+- Server metrics UI and system-level server metrics collection.
+
+### Fixed
+
+- CPU metrics script now uses a two-line `printf` for correct `awk` parsing.
+
+## [0.9.0] - 2026-05-14
+
+### Added
+
+- Buildpack deploys; Docker cleanup configuration; Traefik `redirect-regex`
+  middleware.
+- Port-conflict detection for deployment targets.
+- Notification channels; Traefik middleware; Bitbucket/Gitea providers; Nixpacks
+  builds.
+- Observability CLI commands.
+
+### Fixed
+
+- Assorted backup and deploy bugs.
+
+## [0.8.x] - 2026
+
+Stabilization and refactor series. Highlights:
+
+- One-click GitHub App manifest flow (`0.8.3`).
+- Profile session revocation; signup/profile hardening.
+- Development-task runner hardening: fail stalled tasks, permission gating,
+  unusable-sandbox-runner diagnostics.
+- Install/upgrade robustness: stale volume handling, TTY redirect, timeout
+  diagnostics, readiness-timeout failures, tunnel sidecar preservation.
+- Numerous client-side load-failure surfaces and a dashboard UX audit.
+- Large refactors splitting oversized modules (backups, notifications, CLI
+  install flow, dev tasks) per the 300/500-line hygiene rules.
+
+## [0.5.x – 0.7.x] - 2026
+
+Early control-plane, CLI, deployment, and backup foundations. See git history
+(`git log v0.5.0..v0.8.0`) for detail.
+
+[Unreleased]: https://github.com/daoflow/daoflow/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/daoflow/daoflow/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/daoflow/daoflow/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/daoflow/daoflow/compare/v0.8.8...v0.9.0

--- a/packages/server/src/db/services/deployment-watchdog.test.ts
+++ b/packages/server/src/db/services/deployment-watchdog.test.ts
@@ -130,6 +130,17 @@ describe("deployment watchdog", () => {
 
     const eventRows = await db.select().from(events).where(eq(events.resourceId, deploymentId));
     expect(eventRows.some((row) => row.kind === "deployment.watchdog.failed")).toBe(true);
+
+    // Charter §10: the diagnosis insight must link back to the exact persisted
+    // log line and event rows, not opaque static identifiers.
+    const insight = asRecord(asRecord(deployment?.configSnapshot).insight);
+    const evidence = (insight.evidence as Array<Record<string, unknown>>) ?? [];
+    const watchdogEvidence = evidence.find((entry) => entry.kind === "watchdog");
+    expect(watchdogEvidence).toBeDefined();
+    const watchdogEvent = eventRows.find((row) => row.kind === "deployment.watchdog.failed");
+    expect(watchdogEvidence?.eventId).toBe(watchdogEvent?.id);
+    expect(typeof watchdogEvidence?.logId).toBe("number");
+    expect(logRows.some((row) => row.id === watchdogEvidence?.logId)).toBe(true);
   });
 
   it("ignores fresh active deployments and already terminal deployments", async () => {

--- a/packages/server/src/db/services/deployment-watchdog.ts
+++ b/packages/server/src/db/services/deployment-watchdog.ts
@@ -96,6 +96,7 @@ function buildWatchdogInsight(input: {
   lastHeartbeatAt: string;
   timeoutMs: number;
   staleForMs: number;
+  evidenceRefs?: { eventId?: number | null; logId?: number | null };
 }) {
   const safeActions = Array.from(
     new Set([
@@ -115,6 +116,10 @@ function buildWatchdogInsight(input: {
       {
         kind: "watchdog",
         id: "deployment-watchdog-timeout",
+        // Link the diagnosis back to the exact persisted rows (charter §10:
+        // "any AI-generated diagnosis must link back to exact log lines or event IDs").
+        eventId: input.evidenceRefs?.eventId ?? null,
+        logId: input.evidenceRefs?.logId ?? null,
         title: "Progress heartbeat timed out",
         detail: `The last recorded deployment heartbeat was ${input.lastHeartbeatAt}.`
       }
@@ -142,14 +147,6 @@ async function markDeploymentFailedByWatchdog(input: {
   const previousStatus = current.status;
   const existingSnapshot = asRecord(current.configSnapshot);
   const previousInsight = asRecord(existingSnapshot.insight);
-  const insight = buildWatchdogInsight({
-    previousInsight,
-    serviceName: current.serviceName,
-    previousStatus,
-    lastHeartbeatAt,
-    timeoutMs: input.timeoutMs,
-    staleForMs
-  });
 
   const error = {
     code: "DEPLOYMENT_WATCHDOG_TIMEOUT",
@@ -161,26 +158,15 @@ async function markDeploymentFailedByWatchdog(input: {
     timeoutMs: input.timeoutMs
   };
 
-  const configSnapshot = {
-    ...existingSnapshot,
-    insight,
-    watchdog: {
-      detectedAt,
-      previousStatus,
-      lastHeartbeatAt,
-      staleForMs,
-      timeoutMs: input.timeoutMs
-    }
-  };
-
   return db.transaction(async (tx) => {
+    // Transition the deployment first (guarded) so evidence rows are never
+    // written for a deployment another process already concluded.
     const [updated] = await tx
       .update(deployments)
       .set({
         status: DeploymentLifecycleStatus.Failed,
         conclusion: DeploymentConclusion.Failed,
         error,
-        configSnapshot,
         concludedAt: input.now,
         updatedAt: input.now
       })
@@ -196,35 +182,76 @@ async function markDeploymentFailedByWatchdog(input: {
       return null;
     }
 
-    await tx.insert(deploymentLogs).values({
-      deploymentId: current.id,
-      level: "error",
-      message: `${current.serviceName} stopped reporting progress while ${previousStatus}. DaoFlow marked the deployment failed after ${formatStaleDurationSummary(staleForMs)} without a heartbeat.`,
-      source: "system",
-      metadata: {
-        source: "deployment-watchdog",
-        previousStatus,
-        lastHeartbeatAt,
-        timeoutMs: input.timeoutMs
-      },
-      createdAt: input.now
+    const [logRow] = await tx
+      .insert(deploymentLogs)
+      .values({
+        deploymentId: current.id,
+        level: "error",
+        message: `${current.serviceName} stopped reporting progress while ${previousStatus}. DaoFlow marked the deployment failed after ${formatStaleDurationSummary(staleForMs)} without a heartbeat.`,
+        source: "system",
+        metadata: {
+          source: "deployment-watchdog",
+          previousStatus,
+          lastHeartbeatAt,
+          timeoutMs: input.timeoutMs
+        },
+        createdAt: input.now
+      })
+      .returning({ id: deploymentLogs.id });
+
+    const [eventRow] = await tx
+      .insert(events)
+      .values({
+        kind: "deployment.watchdog.failed",
+        resourceType: "deployment",
+        resourceId: current.id,
+        summary: "Deployment failed after progress stalled.",
+        detail: `${current.serviceName} stopped reporting progress while ${previousStatus}. Last heartbeat: ${lastHeartbeatAt}.`,
+        severity: "error",
+        metadata: {
+          serviceName: current.serviceName,
+          actorLabel: "deployment-watchdog",
+          previousStatus,
+          timeoutMs: input.timeoutMs
+        },
+        createdAt: input.now
+      })
+      .returning({ id: events.id });
+
+    // Build the diagnosis insight only after the evidence rows exist, so it can
+    // cite their exact primary-key IDs (charter §10).
+    const insight = buildWatchdogInsight({
+      previousInsight,
+      serviceName: current.serviceName,
+      previousStatus,
+      lastHeartbeatAt,
+      timeoutMs: input.timeoutMs,
+      staleForMs,
+      evidenceRefs: {
+        eventId: eventRow?.id ?? null,
+        logId: logRow?.id ?? null
+      }
     });
 
-    await tx.insert(events).values({
-      kind: "deployment.watchdog.failed",
-      resourceType: "deployment",
-      resourceId: current.id,
-      summary: "Deployment failed after progress stalled.",
-      detail: `${current.serviceName} stopped reporting progress while ${previousStatus}. Last heartbeat: ${lastHeartbeatAt}.`,
-      severity: "error",
-      metadata: {
-        serviceName: current.serviceName,
-        actorLabel: "deployment-watchdog",
-        previousStatus,
-        timeoutMs: input.timeoutMs
-      },
-      createdAt: input.now
-    });
+    await tx
+      .update(deployments)
+      .set({
+        configSnapshot: {
+          ...existingSnapshot,
+          insight,
+          watchdog: {
+            detectedAt,
+            previousStatus,
+            lastHeartbeatAt,
+            staleForMs,
+            timeoutMs: input.timeoutMs,
+            eventId: eventRow?.id ?? null,
+            logId: logRow?.id ?? null
+          }
+        },
+        updatedAt: input.now
+      })
+      .where(eq(deployments.id, current.id));
 
     await tx.insert(auditEntries).values({
       actorType: "system",
@@ -242,7 +269,9 @@ async function markDeploymentFailedByWatchdog(input: {
         resourceLabel: current.serviceName,
         detail: `${current.serviceName} stopped reporting progress while ${previousStatus}. Last heartbeat: ${lastHeartbeatAt}.`,
         previousStatus,
-        timeoutMs: input.timeoutMs
+        timeoutMs: input.timeoutMs,
+        eventId: eventRow?.id ?? null,
+        logId: logRow?.id ?? null
       }
     });
 

--- a/packages/server/src/db/services/managed-databases.ts
+++ b/packages/server/src/db/services/managed-databases.ts
@@ -24,6 +24,7 @@ import { updateService } from "./services";
 import { createBackupPolicy } from "./storage-management-policies";
 import { createVolume } from "./storage-management-volumes";
 import { db } from "../connection";
+import { auditEntries } from "../schema/audit";
 import { projects } from "../schema/projects";
 import { services } from "../schema/services";
 import type { AppRole } from "@daoflow/shared";
@@ -237,6 +238,30 @@ export async function createManagedDatabase(input: CreateManagedDatabaseInput) {
   });
   if (!deployment) throw new Error("Failed to create deployment record.");
   await dispatchDeploymentExecution(deployment);
+
+  // Audit the managed-database provisioning itself. The sub-resources (service,
+  // volume, backup policy, deployment) each emit their own audit entries, but the
+  // top-level mutation must record the actor and intent for the whole operation
+  // (charter §14: every write path is auditable).
+  await db.insert(auditEntries).values({
+    actorType: "user",
+    actorId: input.requestedByUserId,
+    actorEmail: input.requestedByEmail,
+    actorRole: input.requestedByRole,
+    targetResource: `service/${scope.service.id}`,
+    action: "managed_database.create",
+    inputSummary: `Provisioned ${definition.label} managed database "${serviceName}"`,
+    permissionScope: "service:update",
+    outcome: "success",
+    metadata: {
+      resourceType: "managed-database",
+      resourceId: scope.service.id,
+      resourceLabel: serviceName,
+      kind: input.kind,
+      serverId: input.serverId,
+      deploymentId: deployment.id
+    }
+  });
 
   return {
     status: "ok" as const,


### PR DESCRIPTION
## Why

Hardening pass against the product charter. The 15-milestone e2e roadmap is implemented in code; the remaining gap is *trustworthiness* (charter §20). This PR does verifiable trust work and documents the unverifiable gaps honestly rather than papering over them.

## Changes

### Code (verified by typecheck/lint; DB tests run in CI)
- **Diagnosis links to real evidence (charter §10).** `deployment-watchdog` now writes its `events`/`deployment_logs` rows first inside the transaction, then builds the diagnosis insight citing their exact primary-key IDs (`eventId`/`logId`) instead of an opaque static string. Test extended to assert the linkage.
- **Audit gap closed (charter §14).** `createManagedDatabase` now emits a top-level `managed_database.create` audit entry. Sub-resources were audited individually but the overall provisioning operation was not.

### Docs (no build risk)
- **`CHANGELOG.md`** reconstructed from the `v0.5.x`–`v0.9.2` tag history.
- **1.0 exit criteria** added to the e2e roadmap: real-infra lifecycle proven, agent loop proven, audit completeness enforced, no stub masquerading as live, stranger-verified quickstart.
- **Known Gaps** section: `daoflow drift` is a stub (reads stale cached reports, never queries the live server); remote-SSH deploy/rollback/backup-restore are unverified against real infra; audit logging is ad-hoc and unenforced.
- **`.agents/references/e2e-coverage-and-real-infra.md`**: honest map of what CI mocks (`DISABLE_WORKER=true`) vs the localhost-only real worker job, plus a real-infra harness design.
- **Swarm roadmap**: removed phantom GitHub issue references (`#108`/`#110` do not exist in this repo).

## Explicitly NOT done (and why)
- **Live drift detection** and **real-infra E2E execution** are documented as designs, not implemented. Implementing live-infra code that cannot be run against a real server in this environment would ship unverified code to a release branch — the exact anti-pattern this PR argues against. Tracked in the roadmap's Known Gaps / 1.0 criteria.

## Verification
`bun run format`, `typecheck`, `lint`, `contracts:check`, `skills:check` all pass locally (and via the pre-commit hook). DB-backed unit tests (`deployment-watchdog`, managed-databases) require Postgres and run in CI's Postgres service — not runnable in the authoring environment (no local Docker daemon).

ACPX/Gemini review was skipped: changes are modest (one logic restructure + one audit insert + docs), and the work was time-boxed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added E2E test coverage reference detailing current test scope and documented gaps.
  * Updated roadmap with 1.0 exit criteria and known limitations.
  * Updated roadmap clarifications on tracking issue requirements.

* **Chores**
  * Populated CHANGELOG with reconstructed version history.

* **Audit**
  * Added audit logging for managed database creation operations.

* **Tests**
  * Enhanced deployment watchdog diagnostics with linked evidence references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaoFlow-dev/DaoFlow/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->