### PR TITLE
feat(backups): import approved PostgreSQL archives from S3

### DIFF
--- a/.agents/references/cli-contract.md
+++ b/.agents/references/cli-contract.md
@@ -63,59 +63,83 @@ This file holds the detailed CLI contract, scope map, and agent-facing command r
 
 ## Command Scope Map
 
-| Command                             | Lane                   | Required Scope(s)                                                   | Mutating |
-| ----------------------------------- | ---------------------- | ------------------------------------------------------------------- | -------- |
-| `login`                             | session                | none                                                                | yes      |
-| `whoami`                            | read                   | any valid token                                                     | no       |
-| `capabilities`                      | read                   | any valid token                                                     | no       |
-| `audit`                             | read                   | any valid token                                                     | no       |
-| `approvals`                         | read/command           | any valid token, `approvals:decide`                                 | varies   |
-| `status`                            | read                   | `server:read`                                                       | no       |
-| `server add`                        | command                | `server:write`                                                      | yes      |
-| `server capacity`                   | command                | `server:write`                                                      | yes      |
-| `server proxy`                      | command                | `server:write`                                                      | yes      |
-| `server ops`                        | read/command           | `server:read`, `server:write`                                       | varies   |
-| `tunnels`                           | read/command           | `server:read`, `server:write`                                       | varies   |
-| `log-drains`                        | read/command           | `server:read`, `server:write`                                       | varies   |
-| `access-assets`                     | read/command           | `server:read`, `server:write`                                       | varies   |
-| `maintenance`                       | read/command           | `server:write`                                                      | varies   |
-| `terminal service`                  | command                | `terminal:open`                                                     | yes      |
-| `services`                          | read/command           | `service:read`, `deploy:read`, `diagnostics:read`, `service:update` | varies   |
-| `projects`                          | read/command           | `deploy:read`, `deploy:start`, `service:update`                     | varies   |
-| `templates`                         | read/planning/command  | none, `deploy:read`, `deploy:start`                                 | varies   |
-| `logs`                              | read                   | `logs:read`                                                         | no       |
-| `plan`                              | planning               | `deploy:read`                                                       | no       |
-| `diff`                              | planning               | `deploy:read`                                                       | no       |
-| `doctor`                            | read                   | `server:read`, `logs:read`                                          | no       |
-| `install`                           | local                  | none                                                                | yes      |
-| `upgrade`                           | local                  | none                                                                | yes      |
-| `uninstall`                         | local                  | none                                                                | yes      |
-| `deploy`                            | command                | `deploy:start`                                                      | yes      |
-| `push`                              | command                | `deploy:start`                                                      | yes      |
-| `rollback`                          | command                | `deploy:rollback`                                                   | yes      |
-| `env list`                          | read                   | `env:read`                                                          | no       |
-| `env set`                           | command                | `env:write`                                                         | yes      |
-| `env delete`                        | command                | `env:write`                                                         | yes      |
-| `volumes list`                      | read                   | `volumes:read`                                                      | no       |
-| `volumes register`                  | command                | `volumes:write`                                                     | yes      |
-| `volumes update`                    | command                | `volumes:write`                                                     | yes      |
-| `volumes delete`                    | command                | `volumes:write`                                                     | yes      |
-| `backup list`                       | read                   | `backup:read`                                                       | no       |
-| `backup policy`                     | command                | `backup:run`                                                        | yes      |
-| `backup run`                        | command                | `backup:run`                                                        | yes      |
-| `backup restore`                    | command                | `backup:restore`                                                    | yes      |
-| `backup recovery plan`              | planning               | `backup:read`                                                       | no       |
-| `backup recovery run`               | command/planning       | `backup:run` / `backup:read` for `--dry-run`                        | yes      |
-| `backup recovery restore`           | local command/planning | local operator; no API scope                                        | yes      |
-| `backup recovery list`              | read                   | `backup:read`                                                       | no       |
-| `backup recovery inspect`           | read                   | `backup:read`                                                       | no       |
-| `backup recovery download-metadata` | read                   | `backup:read`                                                       | no       |
-| `notifications list`                | read                   | any valid token                                                     | no       |
-| `notifications logs`                | read                   | any valid token                                                     | no       |
+| Command                             | Lane                   | Required Scope(s)                                                                 | Mutating |
+| ----------------------------------- | ---------------------- | --------------------------------------------------------------------------------- | -------- |
+| `login`                             | session                | none                                                                              | yes      |
+| `whoami`                            | read                   | any valid token                                                                   | no       |
+| `capabilities`                      | read                   | any valid token                                                                   | no       |
+| `audit`                             | read                   | any valid token                                                                   | no       |
+| `approvals`                         | read/command           | any valid token, `approvals:decide`                                               | varies   |
+| `status`                            | read                   | `server:read`                                                                     | no       |
+| `server add`                        | command                | `server:write`                                                                    | yes      |
+| `server capacity`                   | command                | `server:write`                                                                    | yes      |
+| `server proxy`                      | command                | `server:write`                                                                    | yes      |
+| `server ops`                        | read/command           | `server:read`, `server:write`                                                     | varies   |
+| `tunnels`                           | read/command           | `server:read`, `server:write`                                                     | varies   |
+| `log-drains`                        | read/command           | `server:read`, `server:write`                                                     | varies   |
+| `access-assets`                     | read/command           | `server:read`, `server:write`                                                     | varies   |
+| `maintenance`                       | read/command           | `server:write`                                                                    | varies   |
+| `terminal service`                  | command                | `terminal:open`                                                                   | yes      |
+| `services`                          | read/command           | `service:read`, `deploy:read`, `diagnostics:read`, `service:update`               | varies   |
+| `projects`                          | read/command           | `deploy:read`, `deploy:start`, `service:update`                                   | varies   |
+| `templates`                         | read/planning/command  | none, `deploy:read`, `deploy:start`                                               | varies   |
+| `logs`                              | read                   | `logs:read`                                                                       | no       |
+| `plan`                              | planning               | `deploy:read`                                                                     | no       |
+| `diff`                              | planning               | `deploy:read`                                                                     | no       |
+| `doctor`                            | read                   | `server:read`, `logs:read`                                                        | no       |
+| `install`                           | local                  | none                                                                              | yes      |
+| `upgrade`                           | local                  | none                                                                              | yes      |
+| `uninstall`                         | local                  | none                                                                              | yes      |
+| `deploy`                            | command                | `deploy:start`                                                                    | yes      |
+| `push`                              | command                | `deploy:start`                                                                    | yes      |
+| `rollback`                          | command                | `deploy:rollback`                                                                 | yes      |
+| `env list`                          | read                   | `env:read`                                                                        | no       |
+| `env set`                           | command                | `env:write`                                                                       | yes      |
+| `env delete`                        | command                | `env:write`                                                                       | yes      |
+| `volumes list`                      | read                   | `volumes:read`                                                                    | no       |
+| `volumes register`                  | command                | `volumes:write`                                                                   | yes      |
+| `volumes update`                    | command                | `volumes:write`                                                                   | yes      |
+| `volumes delete`                    | command                | `volumes:write`                                                                   | yes      |
+| `backup list`                       | read                   | `backup:read`                                                                     | no       |
+| `backup destination files`          | read                   | `backup:read`                                                                     | no       |
+| `backup external list`              | read                   | `backup:read`                                                                     | no       |
+| `backup external register`          | command                | `backup:restore`                                                                  | yes      |
+| `backup external verify`            | command                | `backup:restore`                                                                  | yes      |
+| `backup external restore`           | planning/command       | `backup:read` for `--dry-run`; `approvals:create`, `backup:restore` for execution | yes      |
+| `backup policy`                     | command                | `backup:run`                                                                      | yes      |
+| `backup run`                        | command                | `backup:run`                                                                      | yes      |
+| `backup restore`                    | command                | `backup:restore`                                                                  | yes      |
+| `backup recovery plan`              | planning               | `backup:read`                                                                     | no       |
+| `backup recovery run`               | command/planning       | `backup:run` / `backup:read` for `--dry-run`                                      | yes      |
+| `backup recovery restore`           | local command/planning | local operator; no API scope                                                      | yes      |
+| `backup recovery list`              | read                   | `backup:read`                                                                     | no       |
+| `backup recovery inspect`           | read                   | `backup:read`                                                                     | no       |
+| `backup recovery download-metadata` | read                   | `backup:read`                                                                     | no       |
+| `notifications list`                | read                   | any valid token                                                                   | no       |
+| `notifications logs`                | read                   | any valid token                                                                   | no       |
 
 - `daoflow backup restore --dry-run` is a planning-lane preview backed by `backupRestorePlan` and requires only `backup:read`
 - `daoflow backup restore --yes` queues the restore and requires `backup:restore`
 - If an operator wants a human approval gate before restore execution, create a separate `requestApproval` with `approvals:create`
+
+## External Backup Artifact Contract
+
+- `daoflow backup destination files --id <destination> [--prefix <prefix>]` reads only objects under the destination's server-enforced approved external-import prefix through `externalBackupObjects`; the CLI never broadens that prefix locally.
+- `daoflow backup destination add --provider s3 --allow-external-imports --external-import-prefix <prefix>` enables the import boundary. Enabling imports without a prefix, using the flags for a non-S3 provider, or supplying a size limit without enabling imports fails locally before mutation.
+- `--max-external-import-bytes <bytes>` is optional when imports are enabled and is limited to a positive value no greater than `2147483648`.
+- Destination dry-runs and JSON responses never print access keys, secret keys, OAuth tokens, rclone configuration, or other credentials.
+- `daoflow backup external list [--destination <id>] [--limit <n>]` reads `externalBackupArtifacts` and visibly reports external origin, exact object key, pinned version/ETag identity, size, SHA-256 checksum, and status.
+- `daoflow backup external register --destination <id> --object-key <key> --postgres-major <n> --dry-run|--yes` validates the exact relative object key locally. Dry-run is local and exits `3`; execution calls `registerExternalBackupArtifact` and requires `backup:restore`.
+- `daoflow backup external verify --artifact-id <id> --dry-run|--yes` previews locally and exits `3`; execution calls `triggerExternalArtifactTestRestore` and requires `backup:restore`.
+- `daoflow backup external restore --artifact-id <id> --target-volume <id> --dry-run|--yes [--reason <text>]` calls `externalArtifactRestorePlan` with `backup:read` for dry-run and exits `3`. Execution calls `requestExternalArtifactRestoreApproval` with `{ artifactId, targetVolumeId, reason }` and requires both `approvals:create` and `backup:restore`.
+- External production restore execution is approval-only. The CLI must never queue or invoke a production restore directly; successful output must explicitly state that approval was requested and that a different authorized actor must approve it. If `--reason` is omitted, use a safe reason of at least 12 characters.
+- External command JSON success shapes:
+  - destination files: `{ "ok": true, "data": { "destination": { "id": string, "name": string, "provider": string }, "prefix": string, "objects": [{ "key": string, "name": string, "size": number, "lastModified": string | null, "etag": string | null, "versionId": string | null }] } }`
+  - external list: `{ "ok": true, "data": { "artifacts": [{ "id": string, "destinationId": string, "destinationName": string, "objectKey": string, "objectVersion": string | null, "objectEtag": string | null, "sizeBytes": number | string, "sha256": string | null, "status": string, "verifiedAt": string | null }] } }`
+  - register: `{ "ok": true, "data": { "artifact": object, "workflowId": string, "nextAction": string } }`
+  - verify: `{ "ok": true, "data": { "id": string, "artifactId": string, "status": string } }`
+  - restore dry-run: `{ "ok": true, "data": { "dryRun": true, "plan": object } }`
+  - restore execution: `{ "ok": true, "data": { "approvalRequested": true, "request": object, "nextAction": "A different authorized actor must approve this request before any production restore can run." } }`
 
 ## Control-plane Recovery Contract
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "packages/cli": {
       "name": "@daoflow/cli",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "bin": {
         "daoflow": "./src/index.ts",
       },
@@ -50,7 +50,7 @@
     },
     "packages/client": {
       "name": "@daoflow/client",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@base-ui/react": "1.6.0",
         "@daoflow/shared": "workspace:*",
@@ -88,7 +88,7 @@
     },
     "packages/mcp": {
       "name": "@daoflow/mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "bin": {
         "daoflow-mcp": "./src/index.ts",
       },
@@ -106,9 +106,10 @@
     },
     "packages/server": {
       "name": "@daoflow/server",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@1password/sdk": "0.4.0",
+        "@aws-sdk/client-s3": "3.1090.0",
         "@daoflow/shared": "workspace:*",
         "@hono/trpc-server": "0.4.2",
         "@sandbank.dev/boxlite": "0.7.1",
@@ -144,7 +145,7 @@
     },
     "packages/shared": {
       "name": "@daoflow/shared",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "zod": "4.3.6",
       },
@@ -170,6 +171,42 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.18", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-IImkbEyXdV6/uaF5r6Wkk+8718mQw1ll83j0a4a30R3JM/rHVFdWAiT4jtJpFjJiIwM/oJ6SxIxr0z2TaQUGqw=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1090.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.18", "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-node": "^3.972.70", "@aws-sdk/middleware-sdk-s3": "^3.972.64", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-R6GX9cd1jljwzZ8xFmgAI/hHCuX1MobIKBdsymv7WL9SENvO9Vgz9KOR6avTnu0Ao+w1LmxnTe+jqmZXEn7Q/Q=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.975.3", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.36", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.4", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.61", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.4", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-login": "^3.972.66", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.66", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.70", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.59", "@aws-sdk/credential-provider-http": "^3.972.61", "@aws-sdk/credential-provider-ini": "^3.973.4", "@aws-sdk/credential-provider-process": "^3.972.59", "@aws-sdk/credential-provider-sso": "^3.973.3", "@aws-sdk/credential-provider-web-identity": "^3.972.65", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/credential-provider-imds": "^4.4.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.3", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/token-providers": "3.1088.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.65", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.64", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RBi43anhDBUv+HCfxCOXwGOE7GmT4n7ChV04Mwr22RhXTNcamW/iWnJlOotDPCZSrJ4dEvhZSiWWQMwLX+ZhFA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.33", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/signature-v4-multi-region": "^3.996.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/fetch-http-handler": "^5.6.6", "@smithy/node-http-handler": "^4.9.6", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.41", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1088.0", "", { "dependencies": { "@aws-sdk/core": "^3.975.3", "@aws-sdk/nested-clients": "^3.997.33", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.4", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.36", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -599,6 +636,18 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
+    "@smithy/core": ["@smithy/core@3.29.5", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.10", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.7", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.6", "", { "dependencies": { "@smithy/core": "^3.29.5", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/core": ["@swc/core@1.15.18", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.18", "@swc/core-darwin-x64": "1.15.18", "@swc/core-linux-arm-gnueabihf": "1.15.18", "@swc/core-linux-arm64-gnu": "1.15.18", "@swc/core-linux-arm64-musl": "1.15.18", "@swc/core-linux-x64-gnu": "1.15.18", "@swc/core-linux-x64-musl": "1.15.18", "@swc/core-win32-arm64-msvc": "1.15.18", "@swc/core-win32-ia32-msvc": "1.15.18", "@swc/core-win32-x64-msvc": "1.15.18" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA=="],
@@ -900,6 +949,8 @@
     "bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 

--- a/docs/docs/backups/index.md
+++ b/docs/docs/backups/index.md
@@ -21,7 +21,7 @@ manual `backup run` or restore operations.
 | [Policies](./policies)               | Define what to backup, when, and retention rules |
 | [Runs](./runs)                       | View backup execution history                    |
 | [Restore](./restore)                 | Restore from a specific backup                   |
-| [S3 Storage](./s3-storage)           | Configure remote backup storage                  |
+| [S3 Storage](./s3-storage)           | Configure storage and approved archive imports   |
 | [Control-plane recovery](./recovery) | Create and verify DaoFlow recovery bundles       |
 
 ## Service Detail Workflow
@@ -51,6 +51,14 @@ daoflow backup list --json
 
 # Restore from a backup
 daoflow backup restore --backup-run-id bkp_run_123 --yes
+
+# Register and test an existing PostgreSQL custom archive from approved S3 storage
+daoflow backup external register \
+  --destination dest_123 \
+  --object-key database-imports/customer.dump \
+  --postgres-major 17 \
+  --yes
+daoflow backup external verify --artifact-id xba_123 --yes
 
 # Plan and run a control-plane recovery bundle
 daoflow backup recovery plan --destination dest_123 --json

--- a/docs/docs/backups/restore.md
+++ b/docs/docs/backups/restore.md
@@ -31,6 +31,43 @@ daoflow backup restore --backup-run-id bkp_run_123 --dry-run --json
 7. **Verify** — capture completion or failure in restore metadata
 8. **Record** — keep the restore request and source backup run immutable
 
+## Restoring an External PostgreSQL Archive
+
+An imported archive follows a stricter sequence than a DaoFlow-created backup:
+
+1. Register the exact S3 object under an approved destination prefix.
+2. Wait for archive inspection and SHA-256 registration to complete.
+3. Run an isolated test restore. The disposable PostgreSQL target has no production network,
+   volume, or credentials.
+4. Select the intended PostgreSQL target volume and preview the production plan.
+5. Request production approval. A different authorized owner or admin approves and dispatches the
+   restore.
+
+```bash
+daoflow backup external list --json
+daoflow backup external verify --artifact-id xba_123 --yes --json
+
+# Read-only plan; exits with the normal dry-run status.
+daoflow backup external restore \
+  --artifact-id xba_123 \
+  --target-volume vol_123 \
+  --dry-run \
+  --json
+
+# Creates an approval request. It does not restore directly.
+daoflow backup external restore \
+  --artifact-id xba_123 \
+  --target-volume vol_123 \
+  --reason "Restore the verified migration archive during the approved window." \
+  --yes \
+  --json
+```
+
+Production planning is unavailable until isolated verification succeeds. The approval snapshot
+binds the artifact checksum, S3 version or ETag, destination revision, selected volume, target
+server, mount path, and PostgreSQL identity. Any change invalidates dispatch instead of restoring a
+different object or target.
+
 ## Approval Gates
 
 Approval requests keep the human decision separate while making the approved handoff durable:
@@ -57,8 +94,8 @@ the underlying problem is corrected.
 ## Required Scopes
 
 - `backup:read` — to preview a restore plan with `--dry-run`
-- `backup:restore` — to queue a direct restore outside an approval-gated flow
-- `approvals:create` — to create an approval-gated restore request
+- `backup:restore` — to queue a direct restore or request an external-artifact production restore
+- `approvals:create` — to create an approval-gated restore request; external-artifact restores also require `backup:restore`
 - `approvals:decide` — to approve, reject, or retry a dispatch that never reached the worker
 
 ## Safety
@@ -67,5 +104,23 @@ the underlying problem is corrected.
 - Restoring creates a new operation record (never modifies existing)
 - Restore execution requires Temporal mode so requests cannot sit in a fake queue
 - The original backup artifact is never modified
+- External production restores cannot bypass approval
+- External object downloads must match the registered version or ETag, size, and SHA-256
 - Restore status is recorded even when application-specific rehydration still requires operator follow-through
 - All restores appear in the audit trail
+
+## QA Checklist for External Imports
+
+Use an isolated QA Compose project with its own PostgreSQL, Temporal, Redis, S3-compatible test
+storage, network, and volumes. Do not point a feature branch at a shared database with a different
+migration chain.
+
+1. Upload a small custom-format `pg_dump` archive under the approved prefix.
+2. Confirm an outside-prefix key, missing identity, oversized object, and plain SQL dump are rejected.
+3. Register the valid archive and confirm its pinned identity and SHA-256 are visible.
+4. Run the isolated test restore and verify expected schemas/tables plus unchanged live-database
+   sentinel data.
+5. Preview production restore against a disposable target, request approval, approve with a second
+   actor, and verify the expected data.
+6. Confirm temporary download files and verifier containers are removed after both success and
+   forced failure.

--- a/docs/docs/backups/s3-storage.md
+++ b/docs/docs/backups/s3-storage.md
@@ -68,3 +68,51 @@ s3://bucket/daoflow/
 daoflow doctor --json
 # Includes S3 connectivity check
 ```
+
+## Importing Existing PostgreSQL Archives
+
+External archive import is disabled by default. Enable it only on an S3-compatible destination and
+set a narrow approved prefix such as `database-imports/`. DaoFlow rejects keys outside that prefix,
+objects above the configured byte limit, destinations using archive or rclone encryption, and
+objects without a version ID or ETag.
+
+The destination form exposes three settings:
+
+- **Allow existing archive imports** — explicit opt-in
+- **Approved prefix** — the only object-key namespace DaoFlow may browse or import
+- **Maximum bytes** — enforced against both S3 metadata and the streamed download
+
+CLI-only setup uses the equivalent destination flags:
+
+```bash
+daoflow backup destination add \
+  --name migration-archives \
+  --provider s3 \
+  --bucket company-backups \
+  --region us-east-1 \
+  --allow-external-imports \
+  --external-import-prefix database-imports/ \
+  --max-external-import-bytes 2147483648 \
+  --yes
+```
+
+Browse only the approved namespace, then register an exact key:
+
+```bash
+daoflow backup destination files --id dest_123 --json
+
+daoflow backup external register \
+  --destination dest_123 \
+  --object-key database-imports/customer.dump \
+  --postgres-major 17 \
+  --yes \
+  --json
+```
+
+Registration runs in the worker. DaoFlow pins the S3 version ID or ETag, streams the object while
+calculating SHA-256, enforces the byte limit again, and inspects the archive with `pg_restore
+--list`. V1 accepts PostgreSQL custom-format archives only. Imported objects become first-class
+external artifacts; DaoFlow does not create a fake backup policy or backup run for them.
+
+Changing or deleting the source object does not silently retarget the artifact. Later verification
+and restore downloads reuse the pinned version or ETag and must reproduce the stored SHA-256.

--- a/docs/static/contracts/api-contract.json
+++ b/docs/static/contracts/api-contract.json
@@ -1243,6 +1243,25 @@
           },
           "localPath": {
             "type": "string"
+          },
+          "externalImportEnabled": {
+            "type": "boolean"
+          },
+          "externalImportPrefix": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 1024
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxExternalImportBytes": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 2147483648
           }
         },
         "required": ["name", "provider"],
@@ -3362,6 +3381,111 @@
       }
     },
     {
+      "name": "externalArtifactRestorePlan",
+      "summary": "external Artifact Restore Plan",
+      "path": "/trpc/externalArtifactRestorePlan",
+      "method": "GET",
+      "lane": "planning",
+      "auth": "authenticated",
+      "requiredRoles": ["owner", "admin", "operator", "developer", "viewer", "agent"],
+      "requiredScopes": ["backup:read"],
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "artifactId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "targetVolumeId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          }
+        },
+        "required": ["artifactId", "targetVolumeId"],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "externalBackupArtifact",
+      "summary": "external Backup Artifact",
+      "path": "/trpc/externalBackupArtifact",
+      "method": "GET",
+      "lane": "read",
+      "auth": "authenticated",
+      "requiredRoles": ["owner", "admin", "operator", "developer", "viewer", "agent"],
+      "requiredScopes": ["backup:read"],
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "artifactId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          }
+        },
+        "required": ["artifactId"],
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "externalBackupArtifacts",
+      "summary": "external Backup Artifacts",
+      "path": "/trpc/externalBackupArtifacts",
+      "method": "GET",
+      "lane": "read",
+      "auth": "authenticated",
+      "requiredRoles": ["owner", "admin", "operator", "developer", "viewer", "agent"],
+      "requiredScopes": ["backup:read"],
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "destinationId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "externalBackupObjects",
+      "summary": "external Backup Objects",
+      "path": "/trpc/externalBackupObjects",
+      "method": "GET",
+      "lane": "read",
+      "auth": "authenticated",
+      "requiredRoles": ["owner", "admin", "operator", "developer", "viewer", "agent"],
+      "requiredScopes": ["backup:read"],
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "destinationId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "prefix": {
+            "type": "string",
+            "maxLength": 1024
+          }
+        },
+        "required": ["destinationId"],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "failExecutionJob",
       "summary": "fail Execution Job",
       "path": "/trpc/failExecutionJob",
@@ -4208,6 +4332,39 @@
       }
     },
     {
+      "name": "registerExternalBackupArtifact",
+      "summary": "register External Backup Artifact",
+      "path": "/trpc/registerExternalBackupArtifact",
+      "method": "POST",
+      "lane": "command",
+      "auth": "authenticated",
+      "requiredRoles": ["owner", "admin", "operator"],
+      "requiredScopes": ["backup:restore"],
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "destinationId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          },
+          "objectKey": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 1024
+          },
+          "postgresMajor": {
+            "type": "integer",
+            "minimum": 9,
+            "maximum": 99
+          }
+        },
+        "required": ["destinationId", "objectKey", "postgresMajor"],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "registerGitProvider",
       "summary": "register Git Provider",
       "path": "/trpc/registerGitProvider",
@@ -4493,6 +4650,37 @@
             "additionalProperties": false
           }
         ]
+      }
+    },
+    {
+      "name": "requestExternalArtifactRestoreApproval",
+      "summary": "request External Artifact Restore Approval",
+      "path": "/trpc/requestExternalArtifactRestoreApproval",
+      "method": "POST",
+      "lane": "command",
+      "auth": "authenticated",
+      "requiredRoles": ["owner", "admin", "operator"],
+      "requiredScopes": ["approvals:create", "backup:restore"],
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "artifactId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "targetVolumeId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 12,
+            "maxLength": 280
+          }
+        },
+        "required": ["artifactId", "targetVolumeId", "reason"],
+        "additionalProperties": false
       }
     },
     {
@@ -5733,6 +5921,29 @@
       }
     },
     {
+      "name": "triggerExternalArtifactTestRestore",
+      "summary": "trigger External Artifact Test Restore",
+      "path": "/trpc/triggerExternalArtifactTestRestore",
+      "method": "POST",
+      "lane": "command",
+      "auth": "authenticated",
+      "requiredRoles": ["owner", "admin", "operator"],
+      "requiredScopes": ["backup:restore"],
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "artifactId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32
+          }
+        },
+        "required": ["artifactId"],
+        "additionalProperties": false
+      }
+    },
+    {
       "name": "triggerTestRestore",
       "summary": "trigger Test Restore",
       "path": "/trpc/triggerTestRestore",
@@ -5865,6 +6076,25 @@
           },
           "localPath": {
             "type": "string"
+          },
+          "externalImportEnabled": {
+            "type": "boolean"
+          },
+          "externalImportPrefix": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 1024
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxExternalImportBytes": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 2147483648
           },
           "id": {
             "type": "string",

--- a/docs/static/contracts/cli-contract.json
+++ b/docs/static/contracts/cli-contract.json
@@ -659,6 +659,21 @@
           "required": false
         },
         {
+          "flags": "--allow-external-imports",
+          "description": "Allow importing PostgreSQL archives from this S3 destination",
+          "required": false
+        },
+        {
+          "flags": "--external-import-prefix <prefix>",
+          "description": "Approved S3 object prefix for external imports",
+          "required": false
+        },
+        {
+          "flags": "--max-external-import-bytes <bytes>",
+          "description": "Maximum external import object size in bytes",
+          "required": false
+        },
+        {
           "flags": "--json",
           "description": "Output as JSON",
           "required": false
@@ -708,6 +723,37 @@
       "supportsJson": true,
       "supportsDryRun": false,
       "supportsYes": true
+    },
+    {
+      "path": "backup destination files",
+      "summary": "List objects in a destination's approved external-import prefix",
+      "lane": "read",
+      "requiredScopes": ["backup:read"],
+      "mutating": false,
+      "hasAction": true,
+      "hasSubcommands": false,
+      "aliases": [],
+      "arguments": [],
+      "options": [
+        {
+          "flags": "--id <destination>",
+          "description": "Backup destination ID",
+          "required": true
+        },
+        {
+          "flags": "--prefix <prefix>",
+          "description": "Sub-prefix within the approved import prefix",
+          "required": false
+        },
+        {
+          "flags": "--json",
+          "description": "Output as JSON",
+          "required": false
+        }
+      ],
+      "supportsJson": true,
+      "supportsDryRun": false,
+      "supportsYes": false
     },
     {
       "path": "backup destination test",
@@ -781,6 +827,180 @@
       "supportsJson": true,
       "supportsDryRun": false,
       "supportsYes": false
+    },
+    {
+      "path": "backup external",
+      "summary": "Manage imported external PostgreSQL backup artifacts",
+      "lane": "local",
+      "requiredScopes": [],
+      "mutating": false,
+      "hasAction": false,
+      "hasSubcommands": true,
+      "aliases": [],
+      "arguments": [],
+      "options": [],
+      "supportsJson": false,
+      "supportsDryRun": false,
+      "supportsYes": false
+    },
+    {
+      "path": "backup external list",
+      "summary": "List registered external backup artifacts",
+      "lane": "read",
+      "requiredScopes": ["backup:read"],
+      "mutating": false,
+      "hasAction": true,
+      "hasSubcommands": false,
+      "aliases": [],
+      "arguments": [],
+      "options": [
+        {
+          "flags": "--destination <id>",
+          "description": "Filter by backup destination ID",
+          "required": false
+        },
+        {
+          "flags": "--limit <n>",
+          "description": "Maximum artifacts to show",
+          "required": false
+        },
+        {
+          "flags": "--json",
+          "description": "Output as JSON",
+          "required": false
+        }
+      ],
+      "supportsJson": true,
+      "supportsDryRun": false,
+      "supportsYes": false
+    },
+    {
+      "path": "backup external register",
+      "summary": "Register an exact object as an external PostgreSQL backup artifact",
+      "lane": "command",
+      "requiredScopes": ["backup:restore"],
+      "mutating": true,
+      "hasAction": true,
+      "hasSubcommands": false,
+      "aliases": [],
+      "arguments": [],
+      "options": [
+        {
+          "flags": "--destination <id>",
+          "description": "Backup destination ID",
+          "required": true
+        },
+        {
+          "flags": "--object-key <key>",
+          "description": "Exact approved-prefix object key",
+          "required": true
+        },
+        {
+          "flags": "--postgres-major <n>",
+          "description": "Expected PostgreSQL major version",
+          "required": true
+        },
+        {
+          "flags": "--dry-run",
+          "description": "Preview locally without making an API call",
+          "required": false
+        },
+        {
+          "flags": "-y, --yes",
+          "description": "Execute the registration",
+          "required": false
+        },
+        {
+          "flags": "--json",
+          "description": "Output as JSON",
+          "required": false
+        }
+      ],
+      "supportsJson": true,
+      "supportsDryRun": true,
+      "supportsYes": true
+    },
+    {
+      "path": "backup external restore",
+      "summary": "Request approval to restore an external artifact to a target volume",
+      "lane": "command",
+      "requiredScopes": ["approvals:create", "backup:restore"],
+      "mutating": true,
+      "hasAction": true,
+      "hasSubcommands": false,
+      "aliases": [],
+      "arguments": [],
+      "options": [
+        {
+          "flags": "--artifact-id <id>",
+          "description": "External artifact ID",
+          "required": true
+        },
+        {
+          "flags": "--target-volume <id>",
+          "description": "Target PostgreSQL volume ID",
+          "required": true
+        },
+        {
+          "flags": "--dry-run",
+          "description": "Preview the server restore plan",
+          "required": false
+        },
+        {
+          "flags": "-y, --yes",
+          "description": "Request production restore approval",
+          "required": false
+        },
+        {
+          "flags": "--reason <text>",
+          "description": "Reason for the approval request",
+          "required": false
+        },
+        {
+          "flags": "--json",
+          "description": "Output as JSON",
+          "required": false
+        }
+      ],
+      "supportsJson": true,
+      "supportsDryRun": true,
+      "supportsYes": true
+    },
+    {
+      "path": "backup external verify",
+      "summary": "Queue an isolated test restore for an external artifact",
+      "lane": "command",
+      "requiredScopes": ["backup:restore"],
+      "mutating": true,
+      "hasAction": true,
+      "hasSubcommands": false,
+      "aliases": [],
+      "arguments": [],
+      "options": [
+        {
+          "flags": "--artifact-id <id>",
+          "description": "External artifact ID",
+          "required": true
+        },
+        {
+          "flags": "--dry-run",
+          "description": "Preview locally without making an API call",
+          "required": false
+        },
+        {
+          "flags": "-y, --yes",
+          "description": "Queue the isolated verification",
+          "required": false
+        },
+        {
+          "flags": "--json",
+          "description": "Output as JSON",
+          "required": false
+        }
+      ],
+      "supportsJson": true,
+      "supportsDryRun": true,
+      "supportsYes": true
     },
     {
       "path": "backup list",

--- a/drizzle/0045_huge_human_cannonball.sql
+++ b/drizzle/0045_huge_human_cannonball.sql
@@ -1,0 +1,87 @@
+CREATE TABLE "external_backup_artifacts" (
+	"id" varchar(32) PRIMARY KEY NOT NULL,
+	"team_id" varchar(32) NOT NULL,
+	"destination_id" varchar(32) NOT NULL,
+	"object_key" text NOT NULL,
+	"object_version" text,
+	"object_etag" varchar(512),
+	"size_bytes" text NOT NULL,
+	"content_type" varchar(255),
+	"last_modified" timestamp,
+	"sha256" varchar(64),
+	"archive_format" varchar(32) DEFAULT 'postgres-custom' NOT NULL,
+	"listing_evidence" text,
+	"source_postgres_version" varchar(64) NOT NULL,
+	"verifier_image" text,
+	"status" varchar(20) DEFAULT 'registering' NOT NULL,
+	"register_error" text,
+	"registered_by_user_id" varchar(32),
+	"registered_at" timestamp,
+	"verified_at" timestamp,
+	"latest_verification" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "external_backup_artifacts_identity_check" CHECK ("external_backup_artifacts"."object_version" IS NOT NULL OR "external_backup_artifacts"."object_etag" IS NOT NULL),
+	CONSTRAINT "external_backup_artifacts_size_check" CHECK ("external_backup_artifacts"."size_bytes" ~ '^[0-9]+$' AND "external_backup_artifacts"."size_bytes"::numeric BETWEEN 1 AND 2147483648),
+	CONSTRAINT "external_backup_artifacts_archive_format_check" CHECK ("external_backup_artifacts"."archive_format" = 'postgres-custom'),
+	CONSTRAINT "external_backup_artifacts_source_version_check" CHECK ("external_backup_artifacts"."source_postgres_version" ~ '^[1-9][0-9]*(\.[0-9]+){0,2}$'),
+	CONSTRAINT "external_backup_artifacts_sha256_check" CHECK ("external_backup_artifacts"."sha256" IS NULL OR "external_backup_artifacts"."sha256" ~ '^[a-f0-9]{64}$'),
+	CONSTRAINT "external_backup_artifacts_status_check" CHECK ("external_backup_artifacts"."status" IN ('registering', 'registered', 'verifying', 'verified', 'failed')),
+	CONSTRAINT "external_backup_artifacts_registered_metadata_check" CHECK ((
+        "external_backup_artifacts"."status" IN ('registering', 'failed')
+        OR (
+          "external_backup_artifacts"."sha256" IS NOT NULL
+          AND "external_backup_artifacts"."listing_evidence" IS NOT NULL
+          AND "external_backup_artifacts"."verifier_image" IS NOT NULL
+          AND "external_backup_artifacts"."registered_at" IS NOT NULL
+        )
+      ))
+);
+--> statement-breakpoint
+ALTER TABLE "backup_restores" ALTER COLUMN "backup_run_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "backup_restores" ADD COLUMN "external_artifact_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "backup_restores" ADD COLUMN "target_volume_id" varchar(32);--> statement-breakpoint
+ALTER TABLE "backup_destinations" ADD COLUMN "external_import_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "backup_destinations" ADD COLUMN "external_import_prefix" text;--> statement-breakpoint
+ALTER TABLE "backup_destinations" ADD COLUMN "max_external_import_bytes" text DEFAULT '2147483648' NOT NULL;--> statement-breakpoint
+ALTER TABLE "external_backup_artifacts" ADD CONSTRAINT "external_backup_artifacts_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "external_backup_artifacts" ADD CONSTRAINT "external_backup_artifacts_destination_id_backup_destinations_id_fk" FOREIGN KEY ("destination_id") REFERENCES "public"."backup_destinations"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "external_backup_artifacts" ADD CONSTRAINT "external_backup_artifacts_registered_by_user_id_users_id_fk" FOREIGN KEY ("registered_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "external_backup_artifacts_team_created_idx" ON "external_backup_artifacts" USING btree ("team_id","created_at");--> statement-breakpoint
+CREATE INDEX "external_backup_artifacts_destination_created_idx" ON "external_backup_artifacts" USING btree ("destination_id","created_at");--> statement-breakpoint
+CREATE INDEX "external_backup_artifacts_status_idx" ON "external_backup_artifacts" USING btree ("status");--> statement-breakpoint
+CREATE UNIQUE INDEX "external_backup_artifacts_version_identity_uq" ON "external_backup_artifacts" USING btree ("destination_id","object_key","object_version") WHERE "external_backup_artifacts"."object_version" IS NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "external_backup_artifacts_etag_identity_uq" ON "external_backup_artifacts" USING btree ("destination_id","object_key","object_etag") WHERE "external_backup_artifacts"."object_version" IS NULL;--> statement-breakpoint
+ALTER TABLE "backup_restores" ADD CONSTRAINT "backup_restores_external_artifact_id_external_backup_artifacts_id_fk" FOREIGN KEY ("external_artifact_id") REFERENCES "public"."external_backup_artifacts"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "backup_restores" ADD CONSTRAINT "backup_restores_target_volume_id_volumes_id_fk" FOREIGN KEY ("target_volume_id") REFERENCES "public"."volumes"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "backup_restores_external_artifact_id_idx" ON "backup_restores" USING btree ("external_artifact_id");--> statement-breakpoint
+CREATE INDEX "backup_restores_target_volume_id_idx" ON "backup_restores" USING btree ("target_volume_id");--> statement-breakpoint
+ALTER TABLE "backup_restores" ADD CONSTRAINT "backup_restores_source_xor_check" CHECK ((
+        ("backup_restores"."backup_run_id" IS NOT NULL AND "backup_restores"."external_artifact_id" IS NULL)
+        OR ("backup_restores"."backup_run_id" IS NULL AND "backup_restores"."external_artifact_id" IS NOT NULL)
+      ));--> statement-breakpoint
+ALTER TABLE "backup_restores" ADD CONSTRAINT "backup_restores_external_target_mode_check" CHECK ((
+        ("backup_restores"."backup_run_id" IS NOT NULL AND "backup_restores"."target_volume_id" IS NULL)
+        OR (
+          "backup_restores"."external_artifact_id" IS NOT NULL
+          AND (
+            ("backup_restores"."mode" = 'verification' AND "backup_restores"."target_volume_id" IS NULL)
+            OR ("backup_restores"."mode" = 'restore' AND "backup_restores"."target_volume_id" IS NOT NULL)
+          )
+        )
+      ));--> statement-breakpoint
+ALTER TABLE "backup_destinations" ADD CONSTRAINT "backup_destinations_external_import_settings_check" CHECK ((
+        "backup_destinations"."max_external_import_bytes" ~ '^[0-9]+$'
+        AND "backup_destinations"."max_external_import_bytes"::numeric BETWEEN 1048576 AND 2147483648
+        AND (
+          "backup_destinations"."external_import_enabled" = false
+          OR (
+            "backup_destinations"."provider" = 's3'
+            AND "backup_destinations"."encryption_mode" = 'none'
+            AND "backup_destinations"."external_import_prefix" IS NOT NULL
+            AND char_length(btrim("backup_destinations"."external_import_prefix")) > 0
+            AND "backup_destinations"."external_import_prefix" = btrim("backup_destinations"."external_import_prefix")
+            AND "backup_destinations"."external_import_prefix" !~ '(^/|//|(^|/)\.\.?(/|$)|\\)'
+          )
+        )
+      ));

--- a/drizzle/meta/0045_snapshot.json
+++ b/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,12942 @@
+{
+  "id": "e489e73c-1e8e-472a-a971-f13109d43c29",
+  "prevId": "aeb5f7a9-0fde-4b59-bdd1-fb34879d7c6c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_identities": {
+      "name": "user_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_encrypted": {
+          "name": "access_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_encrypted": {
+          "name": "refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_identities_user_id_idx": {
+          "name": "user_identities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_provider_idx": {
+          "name": "user_identities_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_identities_provider_user_idx": {
+          "name": "user_identities_provider_user_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_identities_user_id_users_id_fk": {
+          "name": "user_identities_user_id_users_id_fk",
+          "tableFrom": "user_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mfa_enrolled_at": {
+          "name": "mfa_enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_avatar": {
+          "name": "has_avatar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "default_team_id": {
+          "name": "default_team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_invalid_before": {
+          "name": "tokens_invalid_before",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invites": {
+      "name": "team_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "team_invites_team_id_idx": {
+          "name": "team_invites_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_invites_email_idx": {
+          "name": "team_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invites_team_id_teams_id_fk": {
+          "name": "team_invites_team_id_teams_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invites_inviter_id_users_id_fk": {
+          "name": "team_invites_inviter_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_id_idx": {
+          "name": "team_members_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_id_idx": {
+          "name": "team_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_avatar": {
+          "name": "has_avatar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_slug_idx": {
+          "name": "teams_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_name_idx": {
+          "name": "teams_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_created_at_idx": {
+          "name": "teams_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_created_by_user_id_users_id_fk": {
+          "name": "teams_created_by_user_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.certificate_assets": {
+      "name": "certificate_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "certificate_pem_encrypted": {
+          "name": "certificate_pem_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_encrypted": {
+          "name": "private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ca_chain_encrypted": {
+          "name": "ca_chain_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domains": {
+          "name": "domains",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "certificate_assets_team_name_idx": {
+          "name": "certificate_assets_team_name_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_assets_team_fingerprint_idx": {
+          "name": "certificate_assets_team_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_assets_team_idx": {
+          "name": "certificate_assets_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_assets_status_idx": {
+          "name": "certificate_assets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "certificate_assets_expires_at_idx": {
+          "name": "certificate_assets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "certificate_assets_team_id_teams_id_fk": {
+          "name": "certificate_assets_team_id_teams_id_fk",
+          "tableFrom": "certificate_assets",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "certificate_assets_created_by_user_id_users_id_fk": {
+          "name": "certificate_assets_created_by_user_id_users_id_fk",
+          "tableFrom": "certificate_assets",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "certificate_assets_id_team_id_unique": {
+          "name": "certificate_assets_id_team_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["id", "team_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managed_ssh_keys": {
+      "name": "managed_ssh_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_type": {
+          "name": "key_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_key_encrypted": {
+          "name": "private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "managed_ssh_keys_team_name_idx": {
+          "name": "managed_ssh_keys_team_name_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_ssh_keys_team_fingerprint_idx": {
+          "name": "managed_ssh_keys_team_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_ssh_keys_team_idx": {
+          "name": "managed_ssh_keys_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managed_ssh_keys_status_idx": {
+          "name": "managed_ssh_keys_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managed_ssh_keys_team_id_teams_id_fk": {
+          "name": "managed_ssh_keys_team_id_teams_id_fk",
+          "tableFrom": "managed_ssh_keys",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "managed_ssh_keys_created_by_user_id_users_id_fk": {
+          "name": "managed_ssh_keys_created_by_user_id_users_id_fk",
+          "tableFrom": "managed_ssh_keys",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environment_variables": {
+      "name": "environment_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_encrypted": {
+          "name": "value_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runtime'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inline'"
+        },
+        "secret_ref": {
+          "name": "secret_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('environment_variable_revision_seq')"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "env_vars_environment_id_idx": {
+          "name": "env_vars_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "env_vars_env_key_branch_idx": {
+          "name": "env_vars_env_key_branch_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environment_variables_environment_id_environments_id_fk": {
+          "name": "environment_variables_environment_id_environments_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environment_variables_updated_by_user_id_users_id_fk": {
+          "name": "environment_variables_updated_by_user_id_users_id_fk",
+          "tableFrom": "environment_variables",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.environments": {
+      "name": "environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "environments_project_id_idx": {
+          "name": "environments_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "environments_project_slug_idx": {
+          "name": "environments_project_slug_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_variables": {
+      "name": "project_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_encrypted": {
+          "name": "value_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runtime'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inline'"
+        },
+        "secret_ref": {
+          "name": "secret_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('environment_variable_revision_seq')"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_vars_project_id_idx": {
+          "name": "project_vars_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_vars_project_key_idx": {
+          "name": "project_vars_project_key_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_variables_project_id_projects_id_fk": {
+          "name": "project_variables_project_id_projects_id_fk",
+          "tableFrom": "project_variables",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_variables_updated_by_user_id_users_id_fk": {
+          "name": "project_variables_updated_by_user_id_users_id_fk",
+          "tableFrom": "project_variables",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "compose_path": {
+          "name": "compose_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "git_provider_id": {
+          "name": "git_provider_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_installation_id": {
+          "name": "git_installation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'main'"
+        },
+        "auto_deploy": {
+          "name": "auto_deploy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_deploy_branch": {
+          "name": "auto_deploy_branch",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_policy": {
+          "name": "preview_policy",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual-approval'"
+        },
+        "preview_policy_revision": {
+          "name": "preview_policy_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_slug_idx": {
+          "name": "projects_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_team_id_idx": {
+          "name": "projects_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_name_idx": {
+          "name": "projects_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_created_at_idx": {
+          "name": "projects_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_team_id_teams_id_fk": {
+          "name": "projects_team_id_teams_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_git_provider_id_git_providers_id_fk": {
+          "name": "projects_git_provider_id_git_providers_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "git_providers",
+          "columnsFrom": ["git_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_git_installation_id_git_installations_id_fk": {
+          "name": "projects_git_installation_id_git_installations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "git_installations",
+          "columnsFrom": ["git_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_created_by_user_id_users_id_fk": {
+          "name": "projects_created_by_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_git_provider_id_team_id_git_providers_id_team_id_fk": {
+          "name": "projects_git_provider_id_team_id_git_providers_id_team_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "git_providers",
+          "columnsFrom": ["git_provider_id", "team_id"],
+          "columnsTo": ["id", "team_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_git_installation_id_team_id_git_installations_id_team_id_fk": {
+          "name": "projects_git_installation_id_team_id_git_installations_id_team_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "git_installations",
+          "columnsFrom": ["git_installation_id", "team_id"],
+          "columnsTo": ["id", "team_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repository_credentials": {
+      "name": "repository_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username_encrypted": {
+          "name": "username_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_encrypted": {
+          "name": "password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_encrypted": {
+          "name": "token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_key_encrypted": {
+          "name": "private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repository_credentials_project_idx": {
+          "name": "repository_credentials_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "repository_credentials_project_status_idx": {
+          "name": "repository_credentials_project_status_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repository_credentials_project_id_projects_id_fk": {
+          "name": "repository_credentials_project_id_projects_id_fk",
+          "tableFrom": "repository_credentials",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_port": {
+          "name": "ssh_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 22
+        },
+        "ssh_user": {
+          "name": "ssh_user",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_key_id": {
+          "name": "ssh_key_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ssh_private_key_encrypted": {
+          "name": "ssh_private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'docker-engine'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending verification'"
+        },
+        "max_concurrent_builds": {
+          "name": "max_concurrent_builds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "max_queued_deployments": {
+          "name": "max_queued_deployments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "docker_version": {
+          "name": "docker_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compose_version": {
+          "name": "compose_version",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "registered_by_user_id": {
+          "name": "registered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "servers_name_idx": {
+          "name": "servers_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "servers_host_idx": {
+          "name": "servers_host_idx",
+          "columns": [
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "servers_team_id_idx": {
+          "name": "servers_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "servers_ssh_key_id_idx": {
+          "name": "servers_ssh_key_id_idx",
+          "columns": [
+            {
+              "expression": "ssh_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "servers_region_idx": {
+          "name": "servers_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "servers_created_at_idx": {
+          "name": "servers_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "servers_team_id_teams_id_fk": {
+          "name": "servers_team_id_teams_id_fk",
+          "tableFrom": "servers",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "servers_ssh_key_id_managed_ssh_keys_id_fk": {
+          "name": "servers_ssh_key_id_managed_ssh_keys_id_fk",
+          "tableFrom": "servers",
+          "tableTo": "managed_ssh_keys",
+          "columnsFrom": ["ssh_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "servers_registered_by_user_id_users_id_fk": {
+          "name": "servers_registered_by_user_id_users_id_fk",
+          "tableFrom": "servers",
+          "tableTo": "users",
+          "columnsFrom": ["registered_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "servers_max_concurrent_builds_check": {
+          "name": "servers_max_concurrent_builds_check",
+          "value": "\"servers\".\"max_concurrent_builds\" between 1 and 20"
+        },
+        "servers_max_queued_deployments_check": {
+          "name": "servers_max_queued_deployments_check",
+          "value": "\"servers\".\"max_queued_deployments\" between 1 and 500"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.server_operation_logs": {
+      "name": "server_operation_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream": {
+          "name": "stream",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "server_operation_logs_operation_idx": {
+          "name": "server_operation_logs_operation_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_operation_logs_created_at_idx": {
+          "name": "server_operation_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_operation_logs_operation_id_server_operations_id_fk": {
+          "name": "server_operation_logs_operation_id_server_operations_id_fk",
+          "tableFrom": "server_operation_logs",
+          "tableTo": "server_operations",
+          "columnsFrom": ["operation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_operations": {
+      "name": "server_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_email": {
+          "name": "requested_by_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_role": {
+          "name": "requested_by_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_scope": {
+          "name": "permission_scope",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "server_operations_server_idx": {
+          "name": "server_operations_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_operations_kind_idx": {
+          "name": "server_operations_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_operations_status_idx": {
+          "name": "server_operations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_operations_created_at_idx": {
+          "name": "server_operations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_operations_server_id_servers_id_fk": {
+          "name": "server_operations_server_id_servers_id_fk",
+          "tableFrom": "server_operations",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "server_operations_requested_by_user_id_users_id_fk": {
+          "name": "server_operations_requested_by_user_id_users_id_fk",
+          "tableFrom": "server_operations",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_build_leases": {
+      "name": "deployment_build_leases",
+      "schema": "",
+      "columns": {
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_token": {
+          "name": "owner_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquired_at": {
+          "name": "acquired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "deployment_build_leases_server_id_idx": {
+          "name": "deployment_build_leases_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_build_leases_server_expires_at_idx": {
+          "name": "deployment_build_leases_server_expires_at_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_build_leases_expires_at_idx": {
+          "name": "deployment_build_leases_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_build_leases_deployment_id_deployments_id_fk": {
+          "name": "deployment_build_leases_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_build_leases",
+          "tableTo": "deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployment_build_leases_server_id_servers_id_fk": {
+          "name": "deployment_build_leases_server_id_servers_id_fk",
+          "tableFrom": "deployment_build_leases",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_logs": {
+      "name": "deployment_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployment_logs_deployment_id_idx": {
+          "name": "deployment_logs_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_logs_created_at_idx": {
+          "name": "deployment_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_logs_deployment_id_deployments_id_fk": {
+          "name": "deployment_logs_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_logs",
+          "tableTo": "deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_queue_reservations": {
+      "name": "deployment_queue_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "deployment_queue_reservations_server_id_idx": {
+          "name": "deployment_queue_reservations_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_queue_reservations_server_expires_at_idx": {
+          "name": "deployment_queue_reservations_server_expires_at_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployment_queue_reservations_expires_at_idx": {
+          "name": "deployment_queue_reservations_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_queue_reservations_server_id_servers_id_fk": {
+          "name": "deployment_queue_reservations_server_id_servers_id_fk",
+          "tableFrom": "deployment_queue_reservations",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_steps": {
+      "name": "deployment_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "deployment_steps_deployment_id_idx": {
+          "name": "deployment_steps_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_steps_deployment_id_deployments_id_fk": {
+          "name": "deployment_steps_deployment_id_deployments_id_fk",
+          "tableFrom": "deployment_steps",
+          "tableTo": "deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployments": {
+      "name": "deployments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_server_id": {
+          "name": "target_server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_name": {
+          "name": "service_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_tag": {
+          "name": "image_tag",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_snapshot": {
+          "name": "config_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "env_vars_encrypted": {
+          "name": "env_vars_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "webhook_delivery_id": {
+          "name": "webhook_delivery_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_target_key": {
+          "name": "webhook_target_key",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_email": {
+          "name": "requested_by_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_role": {
+          "name": "requested_by_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "container_id": {
+          "name": "container_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "concluded_at": {
+          "name": "concluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "deployments_project_id_idx": {
+          "name": "deployments_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployments_environment_id_idx": {
+          "name": "deployments_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployments_server_id_idx": {
+          "name": "deployments_server_id_idx",
+          "columns": [
+            {
+              "expression": "target_server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployments_status_idx": {
+          "name": "deployments_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployments_webhook_delivery_target_idx": {
+          "name": "deployments_webhook_delivery_target_idx",
+          "columns": [
+            {
+              "expression": "webhook_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "webhook_target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "deployments_created_at_idx": {
+          "name": "deployments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployments_project_id_projects_id_fk": {
+          "name": "deployments_project_id_projects_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deployments_target_server_id_servers_id_fk": {
+          "name": "deployments_target_server_id_servers_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "servers",
+          "columnsFrom": ["target_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "deployments_webhook_delivery_id_webhook_deliveries_id_fk": {
+          "name": "deployments_webhook_delivery_id_webhook_deliveries_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "webhook_deliveries",
+          "columnsFrom": ["webhook_delivery_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "deployments_requested_by_user_id_users_id_fk": {
+          "name": "deployments_requested_by_user_id_users_id_fk",
+          "tableFrom": "deployments",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_policies": {
+      "name": "backup_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume_id": {
+          "name": "volume_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_type": {
+          "name": "backup_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "database_engine": {
+          "name": "database_engine",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_off": {
+          "name": "turn_off",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "retention_daily": {
+          "name": "retention_daily",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 7
+        },
+        "retention_weekly": {
+          "name": "retention_weekly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 4
+        },
+        "retention_monthly": {
+          "name": "retention_monthly",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 12
+        },
+        "max_backups": {
+          "name": "max_backups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "storage_target": {
+          "name": "storage_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "backup_policies_volume_id_idx": {
+          "name": "backup_policies_volume_id_idx",
+          "columns": [
+            {
+              "expression": "volume_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backup_policies_volume_id_volumes_id_fk": {
+          "name": "backup_policies_volume_id_volumes_id_fk",
+          "tableFrom": "backup_policies",
+          "tableTo": "volumes",
+          "columnsFrom": ["volume_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "backup_policies_destination_id_backup_destinations_id_fk": {
+          "name": "backup_policies_destination_id_backup_destinations_id_fk",
+          "tableFrom": "backup_policies",
+          "tableTo": "backup_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_restores": {
+      "name": "backup_restores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "backup_run_id": {
+          "name": "backup_run_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_artifact_id": {
+          "name": "external_artifact_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_volume_id": {
+          "name": "target_volume_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restore'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "target_path": {
+          "name": "target_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_result": {
+          "name": "verification_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "backup_restores_backup_run_id_idx": {
+          "name": "backup_restores_backup_run_id_idx",
+          "columns": [
+            {
+              "expression": "backup_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_restores_external_artifact_id_idx": {
+          "name": "backup_restores_external_artifact_id_idx",
+          "columns": [
+            {
+              "expression": "external_artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_restores_target_volume_id_idx": {
+          "name": "backup_restores_target_volume_id_idx",
+          "columns": [
+            {
+              "expression": "target_volume_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_restores_created_at_idx": {
+          "name": "backup_restores_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backup_restores_backup_run_id_backup_runs_id_fk": {
+          "name": "backup_restores_backup_run_id_backup_runs_id_fk",
+          "tableFrom": "backup_restores",
+          "tableTo": "backup_runs",
+          "columnsFrom": ["backup_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "backup_restores_external_artifact_id_external_backup_artifacts_id_fk": {
+          "name": "backup_restores_external_artifact_id_external_backup_artifacts_id_fk",
+          "tableFrom": "backup_restores",
+          "tableTo": "external_backup_artifacts",
+          "columnsFrom": ["external_artifact_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "backup_restores_target_volume_id_volumes_id_fk": {
+          "name": "backup_restores_target_volume_id_volumes_id_fk",
+          "tableFrom": "backup_restores",
+          "tableTo": "volumes",
+          "columnsFrom": ["target_volume_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "backup_restores_triggered_by_user_id_users_id_fk": {
+          "name": "backup_restores_triggered_by_user_id_users_id_fk",
+          "tableFrom": "backup_restores",
+          "tableTo": "users",
+          "columnsFrom": ["triggered_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "backup_restores_mode_check": {
+          "name": "backup_restores_mode_check",
+          "value": "\"backup_restores\".\"mode\" IN ('restore', 'verification')"
+        },
+        "backup_restores_verification_result_mode_check": {
+          "name": "backup_restores_verification_result_mode_check",
+          "value": "\"backup_restores\".\"verification_result\" IS NULL OR \"backup_restores\".\"mode\" = 'verification'"
+        },
+        "backup_restores_source_xor_check": {
+          "name": "backup_restores_source_xor_check",
+          "value": "(\n        (\"backup_restores\".\"backup_run_id\" IS NOT NULL AND \"backup_restores\".\"external_artifact_id\" IS NULL)\n        OR (\"backup_restores\".\"backup_run_id\" IS NULL AND \"backup_restores\".\"external_artifact_id\" IS NOT NULL)\n      )"
+        },
+        "backup_restores_external_target_mode_check": {
+          "name": "backup_restores_external_target_mode_check",
+          "value": "(\n        (\"backup_restores\".\"backup_run_id\" IS NOT NULL AND \"backup_restores\".\"target_volume_id\" IS NULL)\n        OR (\n          \"backup_restores\".\"external_artifact_id\" IS NOT NULL\n          AND (\n            (\"backup_restores\".\"mode\" = 'verification' AND \"backup_restores\".\"target_volume_id\" IS NULL)\n            OR (\"backup_restores\".\"mode\" = 'restore' AND \"backup_restores\".\"target_volume_id\" IS NOT NULL)\n          )\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.backup_runs": {
+      "name": "backup_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "artifact_path": {
+          "name": "artifact_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_format": {
+          "name": "artifact_format",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "database_engine_version": {
+          "name": "database_engine_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "database_image_reference": {
+          "name": "database_image_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_checked_at": {
+          "name": "artifact_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_entries": {
+          "name": "log_entries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "backup_runs_policy_id_idx": {
+          "name": "backup_runs_policy_id_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_runs_status_idx": {
+          "name": "backup_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_runs_created_at_idx": {
+          "name": "backup_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backup_runs_policy_id_backup_policies_id_fk": {
+          "name": "backup_runs_policy_id_backup_policies_id_fk",
+          "tableFrom": "backup_runs",
+          "tableTo": "backup_policies",
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "backup_runs_triggered_by_user_id_users_id_fk": {
+          "name": "backup_runs_triggered_by_user_id_users_id_fk",
+          "tableFrom": "backup_runs",
+          "tableTo": "users",
+          "columnsFrom": ["triggered_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.volumes": {
+      "name": "volumes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mount_path": {
+          "name": "mount_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "volumes_server_id_idx": {
+          "name": "volumes_server_id_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "volumes_name_idx": {
+          "name": "volumes_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "volumes_server_id_servers_id_fk": {
+          "name": "volumes_server_id_servers_id_fk",
+          "tableFrom": "volumes",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backup_destinations": {
+      "name": "backup_destinations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_envelope_version": {
+          "name": "credential_envelope_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_id": {
+          "name": "credential_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_key": {
+          "name": "access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_access_key": {
+          "name": "secret_access_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_provider": {
+          "name": "s3_provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rclone_type": {
+          "name": "rclone_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rclone_config": {
+          "name": "rclone_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rclone_remote_path": {
+          "name": "rclone_remote_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token": {
+          "name": "oauth_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expiry": {
+          "name": "oauth_token_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_mode": {
+          "name": "encryption_mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "encryption_password": {
+          "name": "encryption_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encryption_salt": {
+          "name": "encryption_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename_encryption": {
+          "name": "filename_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'standard'"
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_bytes": {
+          "name": "quota_bytes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota_warning_percent": {
+          "name": "quota_warning_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 80
+        },
+        "external_import_enabled": {
+          "name": "external_import_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "external_import_prefix": {
+          "name": "external_import_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_external_import_bytes": {
+          "name": "max_external_import_bytes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2147483648'"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_test_result": {
+          "name": "last_test_result",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "backup_destinations_team_id_idx": {
+          "name": "backup_destinations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_destinations_provider_idx": {
+          "name": "backup_destinations_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "backup_destinations_org_idx": {
+          "name": "backup_destinations_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "backup_destinations_team_id_teams_id_fk": {
+          "name": "backup_destinations_team_id_teams_id_fk",
+          "tableFrom": "backup_destinations",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "backup_destinations_credentials_state_check": {
+          "name": "backup_destinations_credentials_state_check",
+          "value": "(\n        (\n          \"backup_destinations\".\"credentials_encrypted\" IS NULL\n          AND \"backup_destinations\".\"credential_envelope_version\" IS NULL\n          AND \"backup_destinations\".\"credential_key_id\" IS NULL\n          AND \"backup_destinations\".\"access_key\" IS NULL\n          AND \"backup_destinations\".\"secret_access_key\" IS NULL\n          AND \"backup_destinations\".\"oauth_token\" IS NULL\n          AND \"backup_destinations\".\"rclone_config\" IS NULL\n          AND \"backup_destinations\".\"encryption_password\" IS NULL\n          AND \"backup_destinations\".\"encryption_salt\" IS NULL\n        )\n        OR\n        (\n          \"backup_destinations\".\"credentials_encrypted\" IS NOT NULL\n          AND \"backup_destinations\".\"credential_envelope_version\" IS NOT NULL\n          AND \"backup_destinations\".\"credential_key_id\" IS NOT NULL\n          AND \"backup_destinations\".\"access_key\" IS NULL\n          AND \"backup_destinations\".\"secret_access_key\" IS NULL\n          AND \"backup_destinations\".\"oauth_token\" IS NULL\n          AND \"backup_destinations\".\"rclone_config\" IS NULL\n          AND \"backup_destinations\".\"encryption_password\" IS NULL\n          AND \"backup_destinations\".\"encryption_salt\" IS NULL\n        )\n      )"
+        },
+        "backup_destinations_external_import_settings_check": {
+          "name": "backup_destinations_external_import_settings_check",
+          "value": "(\n        \"backup_destinations\".\"max_external_import_bytes\" ~ '^[0-9]+$'\n        AND \"backup_destinations\".\"max_external_import_bytes\"::numeric BETWEEN 1048576 AND 2147483648\n        AND (\n          \"backup_destinations\".\"external_import_enabled\" = false\n          OR (\n            \"backup_destinations\".\"provider\" = 's3'\n            AND \"backup_destinations\".\"encryption_mode\" = 'none'\n            AND \"backup_destinations\".\"external_import_prefix\" IS NOT NULL\n            AND char_length(btrim(\"backup_destinations\".\"external_import_prefix\")) > 0\n            AND \"backup_destinations\".\"external_import_prefix\" = btrim(\"backup_destinations\".\"external_import_prefix\")\n            AND \"backup_destinations\".\"external_import_prefix\" !~ '(^/|//|(^|/)\\.\\.?(/|$)|\\\\)'\n          )\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_backup_artifacts": {
+      "name": "external_backup_artifacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_version": {
+          "name": "object_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_etag": {
+          "name": "object_etag",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archive_format": {
+          "name": "archive_format",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'postgres-custom'"
+        },
+        "listing_evidence": {
+          "name": "listing_evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_postgres_version": {
+          "name": "source_postgres_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifier_image": {
+          "name": "verifier_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'registering'"
+        },
+        "register_error": {
+          "name": "register_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_by_user_id": {
+          "name": "registered_by_user_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_verification": {
+          "name": "latest_verification",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_backup_artifacts_team_created_idx": {
+          "name": "external_backup_artifacts_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_backup_artifacts_destination_created_idx": {
+          "name": "external_backup_artifacts_destination_created_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_backup_artifacts_status_idx": {
+          "name": "external_backup_artifacts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_backup_artifacts_version_identity_uq": {
+          "name": "external_backup_artifacts_version_identity_uq",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"external_backup_artifacts\".\"object_version\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_backup_artifacts_etag_identity_uq": {
+          "name": "external_backup_artifacts_etag_identity_uq",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_etag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"external_backup_artifacts\".\"object_version\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_backup_artifacts_team_id_teams_id_fk": {
+          "name": "external_backup_artifacts_team_id_teams_id_fk",
+          "tableFrom": "external_backup_artifacts",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_backup_artifacts_destination_id_backup_destinations_id_fk": {
+          "name": "external_backup_artifacts_destination_id_backup_destinations_id_fk",
+          "tableFrom": "external_backup_artifacts",
+          "tableTo": "backup_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "external_backup_artifacts_registered_by_user_id_users_id_fk": {
+          "name": "external_backup_artifacts_registered_by_user_id_users_id_fk",
+          "tableFrom": "external_backup_artifacts",
+          "tableTo": "users",
+          "columnsFrom": ["registered_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_backup_artifacts_identity_check": {
+          "name": "external_backup_artifacts_identity_check",
+          "value": "\"external_backup_artifacts\".\"object_version\" IS NOT NULL OR \"external_backup_artifacts\".\"object_etag\" IS NOT NULL"
+        },
+        "external_backup_artifacts_size_check": {
+          "name": "external_backup_artifacts_size_check",
+          "value": "\"external_backup_artifacts\".\"size_bytes\" ~ '^[0-9]+$' AND \"external_backup_artifacts\".\"size_bytes\"::numeric BETWEEN 1 AND 2147483648"
+        },
+        "external_backup_artifacts_archive_format_check": {
+          "name": "external_backup_artifacts_archive_format_check",
+          "value": "\"external_backup_artifacts\".\"archive_format\" = 'postgres-custom'"
+        },
+        "external_backup_artifacts_source_version_check": {
+          "name": "external_backup_artifacts_source_version_check",
+          "value": "\"external_backup_artifacts\".\"source_postgres_version\" ~ '^[1-9][0-9]*(\\.[0-9]+){0,2}$'"
+        },
+        "external_backup_artifacts_sha256_check": {
+          "name": "external_backup_artifacts_sha256_check",
+          "value": "\"external_backup_artifacts\".\"sha256\" IS NULL OR \"external_backup_artifacts\".\"sha256\" ~ '^[a-f0-9]{64}$'"
+        },
+        "external_backup_artifacts_status_check": {
+          "name": "external_backup_artifacts_status_check",
+          "value": "\"external_backup_artifacts\".\"status\" IN ('registering', 'registered', 'verifying', 'verified', 'failed')"
+        },
+        "external_backup_artifacts_registered_metadata_check": {
+          "name": "external_backup_artifacts_registered_metadata_check",
+          "value": "(\n        \"external_backup_artifacts\".\"status\" IN ('registering', 'failed')\n        OR (\n          \"external_backup_artifacts\".\"sha256\" IS NOT NULL\n          AND \"external_backup_artifacts\".\"listing_evidence\" IS NOT NULL\n          AND \"external_backup_artifacts\".\"verifier_image\" IS NOT NULL\n          AND \"external_backup_artifacts\".\"registered_at\" IS NOT NULL\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.approval_action_dispatches": {
+      "name": "approval_action_dispatches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approval_request_id": {
+          "name": "approval_request_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_version": {
+          "name": "payload_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_payload": {
+          "name": "action_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_action_dispatches_request_idx": {
+          "name": "approval_action_dispatches_request_idx",
+          "columns": [
+            {
+              "expression": "approval_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_action_dispatches_team_idempotency_idx": {
+          "name": "approval_action_dispatches_team_idempotency_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_action_dispatches_status_next_attempt_idx": {
+          "name": "approval_action_dispatches_status_next_attempt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_action_dispatches_lease_expires_at_idx": {
+          "name": "approval_action_dispatches_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_action_dispatches_reconciliation_idx": {
+          "name": "approval_action_dispatches_reconciliation_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_reconciled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_action_dispatches_operation_id_idx": {
+          "name": "approval_action_dispatches_operation_id_idx",
+          "columns": [
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_action_dispatches_approval_request_id_approval_requests_id_fk": {
+          "name": "approval_action_dispatches_approval_request_id_approval_requests_id_fk",
+          "tableFrom": "approval_action_dispatches",
+          "tableTo": "approval_requests",
+          "columnsFrom": ["approval_request_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_action_dispatches_team_id_teams_id_fk": {
+          "name": "approval_action_dispatches_team_id_teams_id_fk",
+          "tableFrom": "approval_action_dispatches",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_requests": {
+      "name": "approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_key": {
+          "name": "binding_key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource": {
+          "name": "target_resource",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_email": {
+          "name": "requested_by_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_role": {
+          "name": "requested_by_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_email": {
+          "name": "resolved_by_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "approval_requests_team_id_idx": {
+          "name": "approval_requests_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_status_idx": {
+          "name": "approval_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_action_type_idx": {
+          "name": "approval_requests_action_type_idx",
+          "columns": [
+            {
+              "expression": "action_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_pending_binding_idx": {
+          "name": "approval_requests_pending_binding_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "binding_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"approval_requests\".\"binding_key\" is not null and \"approval_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_requests_created_at_idx": {
+          "name": "approval_requests_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_requests_team_id_teams_id_fk": {
+          "name": "approval_requests_team_id_teams_id_fk",
+          "tableFrom": "approval_requests",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_requests_requested_by_user_id_users_id_fk": {
+          "name": "approval_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "approval_requests",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "approval_requests_resolved_by_user_id_users_id_fk": {
+          "name": "approval_requests_resolved_by_user_id_users_id_fk",
+          "tableFrom": "approval_requests",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_entries": {
+      "name": "audit_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_resource": {
+          "name": "target_resource",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permission_scope": {
+          "name": "permission_scope",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_entries_actor_id_idx": {
+          "name": "audit_entries_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entries_action_idx": {
+          "name": "audit_entries_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entries_target_resource_idx": {
+          "name": "audit_entries_target_resource_idx",
+          "columns": [
+            {
+              "expression": "target_resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_entries_created_at_idx": {
+          "name": "audit_entries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_kind_idx": {
+          "name": "events_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_resource_idx": {
+          "name": "events_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_at_idx": {
+          "name": "events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_severity_idx": {
+          "name": "events_severity_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_access_logs": {
+      "name": "request_access_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api'"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_name": {
+          "name": "token_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_category": {
+          "name": "error_category",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_scopes": {
+          "name": "required_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_scopes": {
+          "name": "granted_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "request_access_logs_request_id_idx": {
+          "name": "request_access_logs_request_id_idx",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "request_access_logs_created_at_idx": {
+          "name": "request_access_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "request_access_logs_path_idx": {
+          "name": "request_access_logs_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "request_access_logs_status_idx": {
+          "name": "request_access_logs_status_idx",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "request_access_logs_category_idx": {
+          "name": "request_access_logs_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "request_access_logs_outcome_idx": {
+          "name": "request_access_logs_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "request_access_logs_token_idx": {
+          "name": "request_access_logs_token_idx",
+          "columns": [
+            {
+              "expression": "token_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_security_policies": {
+      "name": "account_security_policies",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mfa_requirement": {
+          "name": "mfa_requirement",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'optional'"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_security_policies_requirement_idx": {
+          "name": "account_security_policies_requirement_idx",
+          "columns": [
+            {
+              "expression": "mfa_requirement",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_security_policies_team_id_teams_id_fk": {
+          "name": "account_security_policies_team_id_teams_id_fk",
+          "tableFrom": "account_security_policies",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_security_policies_updated_by_user_id_users_id_fk": {
+          "name": "account_security_policies_updated_by_user_id_users_id_fk",
+          "tableFrom": "account_security_policies",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_type": {
+          "name": "principal_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_user_agent": {
+          "name": "last_used_user_agent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_code": {
+          "name": "last_failure_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure_ip": {
+          "name": "last_failure_ip",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_tokens_principal_idx": {
+          "name": "api_tokens_principal_idx",
+          "columns": [
+            {
+              "expression": "principal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_token_hash_idx": {
+          "name": "api_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_status_idx": {
+          "name": "api_tokens_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_tokens_created_at_idx": {
+          "name": "api_tokens_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_created_by_user_id_users_id_fk": {
+          "name": "api_tokens_created_by_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.principals": {
+      "name": "principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_scopes": {
+          "name": "default_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "principals_type_idx": {
+          "name": "principals_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "principals_name_idx": {
+          "name": "principals_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "principals_linked_user_id_users_id_fk": {
+          "name": "principals_linked_user_id_users_id_fk",
+          "tableFrom": "principals",
+          "tableTo": "users",
+          "columnsFrom": ["linked_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_id_idx": {
+          "name": "two_factor_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_users_id_fk": {
+          "name": "two_factor_user_id_users_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tunnel_routes": {
+      "name": "tunnel_routes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tunnel_routes_tunnel_id_idx": {
+          "name": "tunnel_routes_tunnel_id_idx",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tunnel_routes_hostname_idx": {
+          "name": "tunnel_routes_hostname_idx",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnel_routes_tunnel_id_tunnels_id_fk": {
+          "name": "tunnel_routes_tunnel_id_tunnels_id_fk",
+          "tableFrom": "tunnel_routes",
+          "tableTo": "tunnels",
+          "columnsFrom": ["tunnel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tunnels": {
+      "name": "tunnels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tunnel_id": {
+          "name": "tunnel_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tunnels_name_team_idx": {
+          "name": "tunnels_name_team_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tunnels_tunnel_id_idx": {
+          "name": "tunnels_tunnel_id_idx",
+          "columns": [
+            {
+              "expression": "tunnel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tunnels_team_id_teams_id_fk": {
+          "name": "tunnels_team_id_teams_id_fk",
+          "tableFrom": "tunnels",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_variables": {
+      "name": "service_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_encrypted": {
+          "name": "value_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_secret": {
+          "name": "is_secret",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runtime'"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inline'"
+        },
+        "secret_ref": {
+          "name": "secret_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch_pattern": {
+          "name": "branch_pattern",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nextval('environment_variable_revision_seq')"
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_vars_service_id_idx": {
+          "name": "service_vars_service_id_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_vars_service_key_branch_idx": {
+          "name": "service_vars_service_key_branch_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branch_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_variables_service_id_services_id_fk": {
+          "name": "service_variables_service_id_services_id_fk",
+          "tableFrom": "service_variables",
+          "tableTo": "services",
+          "columnsFrom": ["service_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_variables_updated_by_user_id_users_id_fk": {
+          "name": "service_variables_updated_by_user_id_users_id_fk",
+          "tableFrom": "service_variables",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_server_id": {
+          "name": "target_server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "image_reference": {
+          "name": "image_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dockerfile_path": {
+          "name": "dockerfile_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compose_service_name": {
+          "name": "compose_service_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "port": {
+          "name": "port",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "healthcheck_path": {
+          "name": "healthcheck_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replica_count": {
+          "name": "replica_count",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inactive'"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "services_project_id_idx": {
+          "name": "services_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "services_environment_id_idx": {
+          "name": "services_environment_id_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "services_env_slug_idx": {
+          "name": "services_env_slug_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_project_id_projects_id_fk": {
+          "name": "services_project_id_projects_id_fk",
+          "tableFrom": "services",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "services_environment_id_environments_id_fk": {
+          "name": "services_environment_id_environments_id_fk",
+          "tableFrom": "services",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "services_target_server_id_servers_id_fk": {
+          "name": "services_target_server_id_servers_id_fk",
+          "tableFrom": "services",
+          "tableTo": "servers",
+          "columnsFrom": ["target_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_schedule_runs": {
+      "name": "service_schedule_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_kind": {
+          "name": "trigger_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logs": {
+          "name": "logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_email": {
+          "name": "requested_by_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_role": {
+          "name": "requested_by_role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_schedule_runs_schedule_idx": {
+          "name": "service_schedule_runs_schedule_idx",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_schedule_runs_service_idx": {
+          "name": "service_schedule_runs_service_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_schedule_runs_status_idx": {
+          "name": "service_schedule_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_schedule_runs_created_idx": {
+          "name": "service_schedule_runs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_schedule_runs_schedule_id_service_schedules_id_fk": {
+          "name": "service_schedule_runs_schedule_id_service_schedules_id_fk",
+          "tableFrom": "service_schedule_runs",
+          "tableTo": "service_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_schedule_runs_service_id_services_id_fk": {
+          "name": "service_schedule_runs_service_id_services_id_fk",
+          "tableFrom": "service_schedule_runs",
+          "tableTo": "services",
+          "columnsFrom": ["service_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_schedule_runs_requested_by_user_id_users_id_fk": {
+          "name": "service_schedule_runs_requested_by_user_id_users_id_fk",
+          "tableFrom": "service_schedule_runs",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_schedules": {
+      "name": "service_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retention_count": {
+          "name": "retention_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20
+        },
+        "notify_on_failure": {
+          "name": "notify_on_failure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "service_schedules_project_idx": {
+          "name": "service_schedules_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_schedules_environment_idx": {
+          "name": "service_schedules_environment_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_schedules_service_idx": {
+          "name": "service_schedules_service_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_schedules_status_idx": {
+          "name": "service_schedules_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "service_schedules_next_run_idx": {
+          "name": "service_schedules_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "service_schedules_project_id_projects_id_fk": {
+          "name": "service_schedules_project_id_projects_id_fk",
+          "tableFrom": "service_schedules",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_schedules_environment_id_environments_id_fk": {
+          "name": "service_schedules_environment_id_environments_id_fk",
+          "tableFrom": "service_schedules",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_schedules_service_id_services_id_fk": {
+          "name": "service_schedules_service_id_services_id_fk",
+          "tableFrom": "service_schedules",
+          "tableTo": "services",
+          "columnsFrom": ["service_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "service_schedules_created_by_user_id_users_id_fk": {
+          "name": "service_schedules_created_by_user_id_users_id_fk",
+          "tableFrom": "service_schedules",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "service_schedules_updated_by_user_id_users_id_fk": {
+          "name": "service_schedules_updated_by_user_id_users_id_fk",
+          "tableFrom": "service_schedules",
+          "tableTo": "users",
+          "columnsFrom": ["updated_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preview_environments": {
+      "name": "preview_environments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "preview_key": {
+          "name": "preview_key",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "env_branch": {
+          "name": "env_branch",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack_name": {
+          "name": "stack_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_domain": {
+          "name": "primary_domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deploying'"
+        },
+        "cleanup_status": {
+          "name": "cleanup_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_requested'"
+        },
+        "last_deployment_id": {
+          "name": "last_deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_deployment_status": {
+          "name": "last_deployment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_deployment_conclusion": {
+          "name": "last_deployment_conclusion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_deployment_action": {
+          "name": "last_deployment_action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deploy'"
+        },
+        "last_deployment_at": {
+          "name": "last_deployment_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "stale_at": {
+          "name": "stale_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_requested_at": {
+          "name": "cleanup_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_completed_at": {
+          "name": "cleanup_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cleanup_deployment_id": {
+          "name": "cleanup_deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "preview_envs_service_key_idx": {
+          "name": "preview_envs_service_key_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preview_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "preview_envs_team_status_idx": {
+          "name": "preview_envs_team_status_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "preview_envs_project_idx": {
+          "name": "preview_envs_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "preview_envs_environment_idx": {
+          "name": "preview_envs_environment_idx",
+          "columns": [
+            {
+              "expression": "environment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "preview_envs_service_idx": {
+          "name": "preview_envs_service_idx",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "preview_envs_last_deployment_idx": {
+          "name": "preview_envs_last_deployment_idx",
+          "columns": [
+            {
+              "expression": "last_deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "preview_envs_cleanup_status_idx": {
+          "name": "preview_envs_cleanup_status_idx",
+          "columns": [
+            {
+              "expression": "cleanup_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "preview_environments_team_id_teams_id_fk": {
+          "name": "preview_environments_team_id_teams_id_fk",
+          "tableFrom": "preview_environments",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "preview_environments_project_id_projects_id_fk": {
+          "name": "preview_environments_project_id_projects_id_fk",
+          "tableFrom": "preview_environments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "preview_environments_environment_id_environments_id_fk": {
+          "name": "preview_environments_environment_id_environments_id_fk",
+          "tableFrom": "preview_environments",
+          "tableTo": "environments",
+          "columnsFrom": ["environment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "preview_environments_service_id_services_id_fk": {
+          "name": "preview_environments_service_id_services_id_fk",
+          "tableFrom": "preview_environments",
+          "tableTo": "services",
+          "columnsFrom": ["service_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_installations": {
+      "name": "git_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_name": {
+          "name": "account_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'organization'"
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_kind": {
+          "name": "credential_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_scopes": {
+          "name": "credential_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_expires_at": {
+          "name": "credential_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_encrypted": {
+          "name": "credential_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_envelope_version": {
+          "name": "credential_envelope_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_key_id": {
+          "name": "credential_key_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_installations_team_id_idx": {
+          "name": "git_installations_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_installations_provider_id_idx": {
+          "name": "git_installations_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_installations_provider_install_idx": {
+          "name": "git_installations_provider_install_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_installations_id_team_id_idx": {
+          "name": "git_installations_id_team_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_installations_team_id_teams_id_fk": {
+          "name": "git_installations_team_id_teams_id_fk",
+          "tableFrom": "git_installations",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_installations_provider_id_git_providers_id_fk": {
+          "name": "git_installations_provider_id_git_providers_id_fk",
+          "tableFrom": "git_installations",
+          "tableTo": "git_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_installations_provider_id_team_id_git_providers_id_team_id_fk": {
+          "name": "git_installations_provider_id_team_id_git_providers_id_team_id_fk",
+          "tableFrom": "git_installations",
+          "tableTo": "git_providers",
+          "columnsFrom": ["provider_id", "team_id"],
+          "columnsTo": ["id", "team_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_provider_setup_states": {
+      "name": "git_provider_setup_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callback_origin": {
+          "name": "callback_origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_public_base_url": {
+          "name": "provider_public_base_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_verifier_encrypted": {
+          "name": "code_verifier_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_provider_setup_states_team_id_idx": {
+          "name": "git_provider_setup_states_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_provider_setup_states_provider_id_idx": {
+          "name": "git_provider_setup_states_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_provider_setup_states_expires_at_idx": {
+          "name": "git_provider_setup_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_provider_setup_states_initiated_by_user_id_idx": {
+          "name": "git_provider_setup_states_initiated_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "initiated_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_provider_setup_states_team_id_teams_id_fk": {
+          "name": "git_provider_setup_states_team_id_teams_id_fk",
+          "tableFrom": "git_provider_setup_states",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_provider_setup_states_provider_id_git_providers_id_fk": {
+          "name": "git_provider_setup_states_provider_id_git_providers_id_fk",
+          "tableFrom": "git_provider_setup_states",
+          "tableTo": "git_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_provider_setup_states_provider_id_team_id_git_providers_id_team_id_fk": {
+          "name": "git_provider_setup_states_provider_id_team_id_git_providers_id_team_id_fk",
+          "tableFrom": "git_provider_setup_states",
+          "tableTo": "git_providers",
+          "columnsFrom": ["provider_id", "team_id"],
+          "columnsTo": ["id", "team_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.git_providers": {
+      "name": "git_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_key_encrypted": {
+          "name": "private_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_base_url": {
+          "name": "internal_base_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ca_certificate_id": {
+          "name": "ca_certificate_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "git_providers_team_id_idx": {
+          "name": "git_providers_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_providers_type_idx": {
+          "name": "git_providers_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_providers_name_team_idx": {
+          "name": "git_providers_name_team_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "git_providers_id_team_id_idx": {
+          "name": "git_providers_id_team_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "git_providers_team_id_teams_id_fk": {
+          "name": "git_providers_team_id_teams_id_fk",
+          "tableFrom": "git_providers",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "git_providers_ca_certificate_id_team_id_certificate_assets_id_team_id_fk": {
+          "name": "git_providers_ca_certificate_id_team_id_certificate_assets_id_team_id_fk",
+          "tableFrom": "git_providers",
+          "tableTo": "certificate_assets",
+          "columnsFrom": ["ca_certificate_id", "team_id"],
+          "columnsTo": ["id", "team_id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_feedback": {
+      "name": "provider_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition": {
+          "name": "transition",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safe_error": {
+          "name": "safe_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "external_deployment_id": {
+          "name": "external_deployment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_status_id": {
+          "name": "external_status_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_comment_id": {
+          "name": "external_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_feedback_idempotency_key_idx": {
+          "name": "provider_feedback_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_sequence_idx": {
+          "name": "provider_feedback_sequence_idx",
+          "columns": [
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_deployment_id_idx": {
+          "name": "provider_feedback_deployment_id_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_team_state_created_at_idx": {
+          "name": "provider_feedback_team_state_created_at_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_claim_idx": {
+          "name": "provider_feedback_claim_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_lease_expires_at_idx": {
+          "name": "provider_feedback_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_target_state_sequence_idx": {
+          "name": "provider_feedback_target_state_sequence_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sequence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_feedback_team_id_teams_id_fk": {
+          "name": "provider_feedback_team_id_teams_id_fk",
+          "tableFrom": "provider_feedback",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_feedback_target_id_provider_feedback_targets_id_fk": {
+          "name": "provider_feedback_target_id_provider_feedback_targets_id_fk",
+          "tableFrom": "provider_feedback",
+          "tableTo": "provider_feedback_targets",
+          "columnsFrom": ["target_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_feedback_deployment_id_deployments_id_fk": {
+          "name": "provider_feedback_deployment_id_deployments_id_fk",
+          "tableFrom": "provider_feedback",
+          "tableTo": "deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_feedback_preview_comments": {
+      "name": "provider_feedback_preview_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_comment_id": {
+          "name": "external_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_feedback_preview_comments_identity_idx": {
+          "name": "provider_feedback_preview_comments_identity_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repository_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pull_request_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_preview_comments_team_id_idx": {
+          "name": "provider_feedback_preview_comments_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_preview_comments_lease_expires_at_idx": {
+          "name": "provider_feedback_preview_comments_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_feedback_preview_comments_team_id_teams_id_fk": {
+          "name": "provider_feedback_preview_comments_team_id_teams_id_fk",
+          "tableFrom": "provider_feedback_preview_comments",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_feedback_preview_comments_project_id_projects_id_fk": {
+          "name": "provider_feedback_preview_comments_project_id_projects_id_fk",
+          "tableFrom": "provider_feedback_preview_comments",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_feedback_targets": {
+      "name": "provider_feedback_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_deployment_id": {
+          "name": "external_deployment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_status_id": {
+          "name": "external_status_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_comment_id": {
+          "name": "external_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provider_feedback_targets_deployment_idx": {
+          "name": "provider_feedback_targets_deployment_idx",
+          "columns": [
+            {
+              "expression": "deployment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_targets_team_id_idx": {
+          "name": "provider_feedback_targets_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provider_feedback_targets_lease_expires_at_idx": {
+          "name": "provider_feedback_targets_lease_expires_at_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_feedback_targets_team_id_teams_id_fk": {
+          "name": "provider_feedback_targets_team_id_teams_id_fk",
+          "tableFrom": "provider_feedback_targets",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_feedback_targets_deployment_id_deployments_id_fk": {
+          "name": "provider_feedback_targets_deployment_id_deployments_id_fk",
+          "tableFrom": "provider_feedback_targets",
+          "tableTo": "deployments",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_key": {
+          "name": "delivery_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_installation_id": {
+          "name": "external_installation_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_key": {
+          "name": "preview_key",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_action": {
+          "name": "preview_action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_digest": {
+          "name": "body_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_attempt_id": {
+          "name": "current_attempt_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error_summary": {
+          "name": "last_error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_provider_key_idx": {
+          "name": "webhook_deliveries_provider_key_idx",
+          "columns": [
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_repo_idx": {
+          "name": "webhook_deliveries_repo_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_status_idx": {
+          "name": "webhook_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_recovery_status_seen_idx": {
+          "name": "webhook_deliveries_recovery_status_seen_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_created_at_idx": {
+          "name": "webhook_deliveries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery_attempts": {
+      "name": "webhook_delivery_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_number": {
+          "name": "attempt_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_summary": {
+          "name": "error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_attempts_delivery_number_idx": {
+          "name": "webhook_delivery_attempts_delivery_number_idx",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_attempts_delivery_status_idx": {
+          "name": "webhook_delivery_attempts_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_attempts_lease_expiry_idx": {
+          "name": "webhook_delivery_attempts_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_attempts_delivery_id_webhook_deliveries_id_fk": {
+          "name": "webhook_delivery_attempts_delivery_id_webhook_deliveries_id_fk",
+          "tableFrom": "webhook_delivery_attempts",
+          "tableTo": "webhook_deliveries",
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_delivery_targets": {
+      "name": "webhook_delivery_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_attempt_id": {
+          "name": "last_attempt_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_summary": {
+          "name": "error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_delivery_targets_delivery_key_idx": {
+          "name": "webhook_delivery_targets_delivery_key_idx",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_delivery_targets_retry_idx": {
+          "name": "webhook_delivery_targets_retry_idx",
+          "columns": [
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_delivery_targets_delivery_id_webhook_deliveries_id_fk": {
+          "name": "webhook_delivery_targets_delivery_id_webhook_deliveries_id_fk",
+          "tableFrom": "webhook_delivery_targets",
+          "tableTo": "webhook_deliveries",
+          "columnsFrom": ["delivery_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_delivery_targets_last_attempt_id_webhook_delivery_attempts_id_fk": {
+          "name": "webhook_delivery_targets_last_attempt_id_webhook_delivery_attempts_id_fk",
+          "tableFrom": "webhook_delivery_targets",
+          "tableTo": "webhook_delivery_attempts",
+          "columnsFrom": ["last_attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.development_task_comments": {
+      "name": "development_task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_comment_id": {
+          "name": "external_comment_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment_kind": {
+          "name": "comment_kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_body_hash": {
+          "name": "last_body_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "development_task_comments_provider_comment_idx": {
+          "name": "development_task_comments_provider_comment_idx",
+          "columns": [
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_comments_task_idx": {
+          "name": "development_task_comments_task_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_comments_run_idx": {
+          "name": "development_task_comments_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_comments_kind_idx": {
+          "name": "development_task_comments_kind_idx",
+          "columns": [
+            {
+              "expression": "comment_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "development_task_comments_task_id_development_tasks_id_fk": {
+          "name": "development_task_comments_task_id_development_tasks_id_fk",
+          "tableFrom": "development_task_comments",
+          "tableTo": "development_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "development_task_comments_run_id_development_task_runs_id_fk": {
+          "name": "development_task_comments_run_id_development_task_runs_id_fk",
+          "tableFrom": "development_task_comments",
+          "tableTo": "development_task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.development_task_events": {
+      "name": "development_task_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "development_task_events_task_idx": {
+          "name": "development_task_events_task_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_events_run_idx": {
+          "name": "development_task_events_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_events_kind_idx": {
+          "name": "development_task_events_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_events_created_at_idx": {
+          "name": "development_task_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "development_task_events_task_id_development_tasks_id_fk": {
+          "name": "development_task_events_task_id_development_tasks_id_fk",
+          "tableFrom": "development_task_events",
+          "tableTo": "development_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "development_task_events_run_id_development_task_runs_id_fk": {
+          "name": "development_task_events_run_id_development_task_runs_id_fk",
+          "tableFrom": "development_task_events",
+          "tableTo": "development_task_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.development_task_runs": {
+      "name": "development_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "runner_id": {
+          "name": "runner_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_profile_id": {
+          "name": "runner_profile_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_provider": {
+          "name": "sandbox_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "codex_profile": {
+          "name": "codex_profile",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_number": {
+          "name": "pull_request_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_deployment_id": {
+          "name": "preview_deployment_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_category": {
+          "name": "failure_category",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "development_task_runs_task_idx": {
+          "name": "development_task_runs_task_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_runs_status_idx": {
+          "name": "development_task_runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_runs_runner_profile_idx": {
+          "name": "development_task_runs_runner_profile_idx",
+          "columns": [
+            {
+              "expression": "runner_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_task_runs_created_at_idx": {
+          "name": "development_task_runs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "development_task_runs_task_id_development_tasks_id_fk": {
+          "name": "development_task_runs_task_id_development_tasks_id_fk",
+          "tableFrom": "development_task_runs",
+          "tableTo": "development_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "development_task_runs_runner_profile_id_sandbox_runner_profiles_id_fk": {
+          "name": "development_task_runs_runner_profile_id_sandbox_runner_profiles_id_fk",
+          "tableFrom": "development_task_runs",
+          "tableTo": "sandbox_runner_profiles",
+          "columnsFrom": ["runner_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.development_tasks": {
+      "name": "development_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_installation_id": {
+          "name": "provider_installation_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_issue_id": {
+          "name": "external_issue_id",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_title": {
+          "name": "issue_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_author": {
+          "name": "issue_author",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "requested_by_external_user": {
+          "name": "requested_by_external_user",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_principal_id": {
+          "name": "requested_by_principal_id",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_run_id": {
+          "name": "current_run_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "development_tasks_provider_issue_idx": {
+          "name": "development_tasks_provider_issue_idx",
+          "columns": [
+            {
+              "expression": "provider_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_tasks_project_idx": {
+          "name": "development_tasks_project_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_tasks_status_idx": {
+          "name": "development_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_tasks_priority_idx": {
+          "name": "development_tasks_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "development_tasks_created_at_idx": {
+          "name": "development_tasks_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "development_tasks_provider_installation_id_git_installations_id_fk": {
+          "name": "development_tasks_provider_installation_id_git_installations_id_fk",
+          "tableFrom": "development_tasks",
+          "tableTo": "git_installations",
+          "columnsFrom": ["provider_installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "development_tasks_project_id_projects_id_fk": {
+          "name": "development_tasks_project_id_projects_id_fk",
+          "tableFrom": "development_tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_runner_profiles": {
+      "name": "sandbox_runner_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'host_docker'"
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_limit": {
+          "name": "cpu_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2
+        },
+        "memory_limit_mb": {
+          "name": "memory_limit_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 4096
+        },
+        "disk_limit_mb": {
+          "name": "disk_limit_mb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 20480
+        },
+        "network_policy": {
+          "name": "network_policy",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default-egress'"
+        },
+        "allowed_commands": {
+          "name": "allowed_commands",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "validation_commands": {
+          "name": "validation_commands",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "codex_auth_mode": {
+          "name": "codex_auth_mode",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_key'"
+        },
+        "codex_config_template": {
+          "name": "codex_config_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disabled'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sandbox_runner_profiles_name_idx": {
+          "name": "sandbox_runner_profiles_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_runner_profiles_provider_idx": {
+          "name": "sandbox_runner_profiles_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_runner_profiles_server_idx": {
+          "name": "sandbox_runner_profiles_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sandbox_runner_profiles_status_idx": {
+          "name": "sandbox_runner_profiles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_runner_profiles_server_id_servers_id_fk": {
+          "name": "sandbox_runner_profiles_server_id_servers_id_fk",
+          "tableFrom": "sandbox_runner_profiles",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_selectors": {
+          "name": "event_selectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "project_filter": {
+          "name": "project_filter",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_filter": {
+          "name": "environment_filter",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_channels_team_id_idx": {
+          "name": "notification_channels_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_channels_type_idx": {
+          "name": "notification_channels_type_idx",
+          "columns": [
+            {
+              "expression": "channel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_channels_enabled_idx": {
+          "name": "notification_channels_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_team_id_teams_id_fk": {
+          "name": "notification_channels_team_id_teams_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_logs": {
+      "name": "notification_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_logs_channel_id_idx": {
+          "name": "notification_logs_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_logs_event_type_idx": {
+          "name": "notification_logs_event_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_logs_sent_at_idx": {
+          "name": "notification_logs_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_logs_channel_id_notification_channels_id_fk": {
+          "name": "notification_logs_channel_id_notification_channels_id_fk",
+          "tableFrom": "notification_logs",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_notification_overrides": {
+      "name": "project_notification_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_notification_overrides_project_id_idx": {
+          "name": "project_notification_overrides_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_notification_overrides_user_id_idx": {
+          "name": "project_notification_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_pushed_at": {
+          "name": "last_pushed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_notification_prefs_user_id_idx": {
+          "name": "user_notification_prefs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_notification_prefs_channel_type_idx": {
+          "name": "user_notification_prefs_channel_type_idx",
+          "columns": [
+            {
+              "expression": "channel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_drain_deliveries": {
+      "name": "log_drain_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drain_id": {
+          "name": "drain_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "log_drain_deliveries_drain_id_idx": {
+          "name": "log_drain_deliveries_drain_id_idx",
+          "columns": [
+            {
+              "expression": "drain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "log_drain_deliveries_status_idx": {
+          "name": "log_drain_deliveries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "log_drain_deliveries_attempted_at_idx": {
+          "name": "log_drain_deliveries_attempted_at_idx",
+          "columns": [
+            {
+              "expression": "attempted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_drain_deliveries_drain_id_log_drains_id_fk": {
+          "name": "log_drain_deliveries_drain_id_log_drains_id_fk",
+          "tableFrom": "log_drain_deliveries",
+          "tableTo": "log_drains",
+          "columnsFrom": ["drain_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_drains": {
+      "name": "log_drains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_type": {
+          "name": "destination_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint_url": {
+          "name": "endpoint_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers_encrypted": {
+          "name": "headers_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_filter": {
+          "name": "service_filter",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "environment_filter": {
+          "name": "environment_filter",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "log_drains_team_id_idx": {
+          "name": "log_drains_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "log_drains_destination_type_idx": {
+          "name": "log_drains_destination_type_idx",
+          "columns": [
+            {
+              "expression": "destination_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "log_drains_status_idx": {
+          "name": "log_drains_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "log_drains_team_id_teams_id_fk": {
+          "name": "log_drains_team_id_teams_id_fk",
+          "tableFrom": "log_drains",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secret_providers": {
+      "name": "secret_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_tested_at": {
+          "name": "last_tested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "secret_providers_team_id_idx": {
+          "name": "secret_providers_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "secret_providers_type_idx": {
+          "name": "secret_providers_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "secret_providers_team_id_teams_id_fk": {
+          "name": "secret_providers_team_id_teams_id_fk",
+          "tableFrom": "secret_providers",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "secret_providers_created_by_user_id_users_id_fk": {
+          "name": "secret_providers_created_by_user_id_users_id_fk",
+          "tableFrom": "secret_providers",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_auth_requests": {
+      "name": "cli_auth_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exchange_code": {
+          "name": "exchange_code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_token_encrypted": {
+          "name": "session_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_email": {
+          "name": "approved_by_email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchanged_at": {
+          "name": "exchanged_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cli_auth_requests_user_code_idx": {
+          "name": "cli_auth_requests_user_code_idx",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_auth_requests_exchange_code_idx": {
+          "name": "cli_auth_requests_exchange_code_idx",
+          "columns": [
+            {
+              "expression": "exchange_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_auth_requests_expires_at_idx": {
+          "name": "cli_auth_requests_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cli_auth_requests_approved_by_user_id_idx": {
+          "name": "cli_auth_requests_approved_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "approved_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_auth_requests_approved_by_user_id_users_id_fk": {
+          "name": "cli_auth_requests_approved_by_user_id_users_id_fk",
+          "tableFrom": "cli_auth_requests",
+          "tableTo": "users",
+          "columnsFrom": ["approved_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.container_registries": {
+      "name": "container_registries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registry_host": {
+          "name": "registry_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_encrypted": {
+          "name": "password_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "container_registries_name_team_idx": {
+          "name": "container_registries_name_team_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "container_registries_host_team_idx": {
+          "name": "container_registries_host_team_idx",
+          "columns": [
+            {
+              "expression": "registry_host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "container_registries_team_id_idx": {
+          "name": "container_registries_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "container_registries_created_at_idx": {
+          "name": "container_registries_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "container_registries_team_id_teams_id_fk": {
+          "name": "container_registries_team_id_teams_id_fk",
+          "tableFrom": "container_registries",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_metric_alerts": {
+      "name": "server_metric_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transition_type": {
+          "name": "transition_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_state": {
+          "name": "previous_state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_state": {
+          "name": "next_state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "measured_value": {
+          "name": "measured_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_value": {
+          "name": "threshold_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "server_metric_alerts_server_occurred_idx": {
+          "name": "server_metric_alerts_server_occurred_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_metric_alerts_occurred_idx": {
+          "name": "server_metric_alerts_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_metric_alerts_server_id_servers_id_fk": {
+          "name": "server_metric_alerts_server_id_servers_id_fk",
+          "tableFrom": "server_metric_alerts",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_metric_delivery_cooldowns": {
+      "name": "server_metric_delivery_cooldowns",
+      "schema": "",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_lease_token": {
+          "name": "delivery_lease_token",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_lease_expires_at": {
+          "name": "delivery_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "server_metric_delivery_cooldowns_lease_idx": {
+          "name": "server_metric_delivery_cooldowns_lease_idx",
+          "columns": [
+            {
+              "expression": "delivery_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_metric_delivery_cooldowns_server_id_servers_id_fk": {
+          "name": "server_metric_delivery_cooldowns_server_id_servers_id_fk",
+          "tableFrom": "server_metric_delivery_cooldowns",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "server_metric_delivery_cooldowns_channel_id_notification_channels_id_fk": {
+          "name": "server_metric_delivery_cooldowns_channel_id_notification_channels_id_fk",
+          "tableFrom": "server_metric_delivery_cooldowns",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "server_metric_delivery_cooldowns_pkey": {
+          "name": "server_metric_delivery_cooldowns_pkey",
+          "columns": ["server_id", "channel_id", "metric_key", "event_type"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_metric_outbox": {
+      "name": "server_metric_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminal_failed_at": {
+          "name": "terminal_failed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "server_metric_outbox_ready_idx": {
+          "name": "server_metric_outbox_ready_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_metric_outbox_server_event_idx": {
+          "name": "server_metric_outbox_server_event_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_metric_outbox_channel_idx": {
+          "name": "server_metric_outbox_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_metric_outbox_alert_id_server_metric_alerts_id_fk": {
+          "name": "server_metric_outbox_alert_id_server_metric_alerts_id_fk",
+          "tableFrom": "server_metric_outbox",
+          "tableTo": "server_metric_alerts",
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "server_metric_outbox_server_id_servers_id_fk": {
+          "name": "server_metric_outbox_server_id_servers_id_fk",
+          "tableFrom": "server_metric_outbox",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "server_metric_outbox_channel_id_notification_channels_id_fk": {
+          "name": "server_metric_outbox_channel_id_notification_channels_id_fk",
+          "tableFrom": "server_metric_outbox",
+          "tableTo": "notification_channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "server_metric_outbox_attempt_count_check": {
+          "name": "server_metric_outbox_attempt_count_check",
+          "value": "\"server_metric_outbox\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.server_metric_policies": {
+      "name": "server_metric_policies",
+      "schema": "",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sample_interval_seconds": {
+          "name": "sample_interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7
+        },
+        "cpu_warn_percent": {
+          "name": "cpu_warn_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cpu_hard_percent": {
+          "name": "cpu_hard_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "memory_warn_percent": {
+          "name": "memory_warn_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "memory_hard_percent": {
+          "name": "memory_hard_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disk_warn_percent": {
+          "name": "disk_warn_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disk_hard_percent": {
+          "name": "disk_hard_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "docker_disk_warn_percent": {
+          "name": "docker_disk_warn_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "docker_disk_hard_percent": {
+          "name": "docker_disk_hard_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cooldown_minutes": {
+          "name": "cooldown_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "server_metric_policies_server_id_servers_id_fk": {
+          "name": "server_metric_policies_server_id_servers_id_fk",
+          "tableFrom": "server_metric_policies",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "server_metric_policies_sample_interval_check": {
+          "name": "server_metric_policies_sample_interval_check",
+          "value": "\"server_metric_policies\".\"sample_interval_seconds\" between 1 and 86400"
+        },
+        "server_metric_policies_retention_check": {
+          "name": "server_metric_policies_retention_check",
+          "value": "\"server_metric_policies\".\"retention_days\" between 1 and 3650"
+        },
+        "server_metric_policies_cpu_thresholds_check": {
+          "name": "server_metric_policies_cpu_thresholds_check",
+          "value": "\"server_metric_policies\".\"cpu_warn_percent\" between 0 and 100 and \"server_metric_policies\".\"cpu_hard_percent\" between 0 and 100 and (\"server_metric_policies\".\"cpu_warn_percent\" = 0 or \"server_metric_policies\".\"cpu_hard_percent\" = 0 or \"server_metric_policies\".\"cpu_warn_percent\" <= \"server_metric_policies\".\"cpu_hard_percent\")"
+        },
+        "server_metric_policies_memory_thresholds_check": {
+          "name": "server_metric_policies_memory_thresholds_check",
+          "value": "\"server_metric_policies\".\"memory_warn_percent\" between 0 and 100 and \"server_metric_policies\".\"memory_hard_percent\" between 0 and 100 and (\"server_metric_policies\".\"memory_warn_percent\" = 0 or \"server_metric_policies\".\"memory_hard_percent\" = 0 or \"server_metric_policies\".\"memory_warn_percent\" <= \"server_metric_policies\".\"memory_hard_percent\")"
+        },
+        "server_metric_policies_disk_thresholds_check": {
+          "name": "server_metric_policies_disk_thresholds_check",
+          "value": "\"server_metric_policies\".\"disk_warn_percent\" between 0 and 100 and \"server_metric_policies\".\"disk_hard_percent\" between 0 and 100 and (\"server_metric_policies\".\"disk_warn_percent\" = 0 or \"server_metric_policies\".\"disk_hard_percent\" = 0 or \"server_metric_policies\".\"disk_warn_percent\" <= \"server_metric_policies\".\"disk_hard_percent\")"
+        },
+        "server_metric_policies_docker_disk_thresholds_check": {
+          "name": "server_metric_policies_docker_disk_thresholds_check",
+          "value": "\"server_metric_policies\".\"docker_disk_warn_percent\" between 0 and 100 and \"server_metric_policies\".\"docker_disk_hard_percent\" between 0 and 100 and (\"server_metric_policies\".\"docker_disk_warn_percent\" = 0 or \"server_metric_policies\".\"docker_disk_hard_percent\" = 0 or \"server_metric_policies\".\"docker_disk_warn_percent\" <= \"server_metric_policies\".\"docker_disk_hard_percent\")"
+        },
+        "server_metric_policies_cooldown_check": {
+          "name": "server_metric_policies_cooldown_check",
+          "value": "\"server_metric_policies\".\"cooldown_minutes\" between 0 and 1440"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.server_metric_states": {
+      "name": "server_metric_states",
+      "schema": "",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "current_state": {
+          "name": "current_state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'healthy'"
+        },
+        "metric_states": {
+          "name": "metric_states",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_collected_at": {
+          "name": "last_collected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_unreachable_at": {
+          "name": "last_unreachable_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_transition_at": {
+          "name": "last_transition_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_alert_at": {
+          "name": "last_alert_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_generation": {
+          "name": "collection_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "collection_lease_owner": {
+          "name": "collection_lease_owner",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_lease_token": {
+          "name": "collection_lease_token",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_lease_expires_at": {
+          "name": "collection_lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "server_metric_states_current_state_idx": {
+          "name": "server_metric_states_current_state_idx",
+          "columns": [
+            {
+              "expression": "current_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_metric_states_collection_lease_idx": {
+          "name": "server_metric_states_collection_lease_idx",
+          "columns": [
+            {
+              "expression": "collection_lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_metric_states_server_id_servers_id_fk": {
+          "name": "server_metric_states_server_id_servers_id_fk",
+          "tableFrom": "server_metric_states",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.server_metrics": {
+      "name": "server_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpu_percent": {
+          "name": "cpu_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_used_percent": {
+          "name": "memory_used_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_used_gb": {
+          "name": "memory_used_gb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_total_gb": {
+          "name": "memory_total_gb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disk_used_percent": {
+          "name": "disk_used_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disk_total_gb": {
+          "name": "disk_total_gb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_in_mb": {
+          "name": "network_in_mb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network_out_mb": {
+          "name": "network_out_mb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "docker_disk_used_percent": {
+          "name": "docker_disk_used_percent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "docker_disk_total_gb": {
+          "name": "docker_disk_total_gb",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collected_at": {
+          "name": "collected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "server_metrics_server_idx": {
+          "name": "server_metrics_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_metrics_server_collected_idx": {
+          "name": "server_metrics_server_collected_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "server_metrics_collected_at_idx": {
+          "name": "server_metrics_collected_at_idx",
+          "columns": [
+            {
+              "expression": "collected_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "server_metrics_server_id_servers_id_fk": {
+          "name": "server_metrics_server_id_servers_id_fk",
+          "tableFrom": "server_metrics",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ssh_host_identities": {
+      "name": "ssh_host_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'observed'"
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_observed_at": {
+          "name": "last_observed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "superseded_by_user_id": {
+          "name": "superseded_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ssh_host_identities_server_key_idx": {
+          "name": "ssh_host_identities_server_key_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "algorithm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_host_identities_active_server_idx": {
+          "name": "ssh_host_identities_active_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"ssh_host_identities\".\"status\" = 'approved'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_host_identities_team_idx": {
+          "name": "ssh_host_identities_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_host_identities_server_idx": {
+          "name": "ssh_host_identities_server_idx",
+          "columns": [
+            {
+              "expression": "server_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ssh_host_identities_status_idx": {
+          "name": "ssh_host_identities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ssh_host_identities_team_id_teams_id_fk": {
+          "name": "ssh_host_identities_team_id_teams_id_fk",
+          "tableFrom": "ssh_host_identities",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ssh_host_identities_server_id_servers_id_fk": {
+          "name": "ssh_host_identities_server_id_servers_id_fk",
+          "tableFrom": "ssh_host_identities",
+          "tableTo": "servers",
+          "columnsFrom": ["server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ssh_host_identities_approved_by_user_id_users_id_fk": {
+          "name": "ssh_host_identities_approved_by_user_id_users_id_fk",
+          "tableFrom": "ssh_host_identities",
+          "tableTo": "users",
+          "columnsFrom": ["approved_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "ssh_host_identities_superseded_by_user_id_users_id_fk": {
+          "name": "ssh_host_identities_superseded_by_user_id_users_id_fk",
+          "tableFrom": "ssh_host_identities",
+          "tableTo": "users",
+          "columnsFrom": ["superseded_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.control_plane_recovery_bundles": {
+      "name": "control_plane_recovery_bundles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_team_id": {
+          "name": "owner_team_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "format_version": {
+          "name": "format_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_fingerprint": {
+          "name": "key_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_rotated_at": {
+          "name": "key_rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_prefix": {
+          "name": "object_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_object_path": {
+          "name": "bundle_object_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest_object_path": {
+          "name": "manifest_object_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_manifest_object_path": {
+          "name": "latest_manifest_object_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bundle_checksum": {
+          "name": "bundle_checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "database_checksum": {
+          "name": "database_checksum",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_result": {
+          "name": "verification_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(71)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temporal_workflow_id": {
+          "name": "temporal_workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temporal_run_id": {
+          "name": "temporal_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "control_plane_recovery_team_idx": {
+          "name": "control_plane_recovery_team_idx",
+          "columns": [
+            {
+              "expression": "owner_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "control_plane_recovery_destination_idx": {
+          "name": "control_plane_recovery_destination_idx",
+          "columns": [
+            {
+              "expression": "destination_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "control_plane_recovery_status_idx": {
+          "name": "control_plane_recovery_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "control_plane_recovery_created_at_idx": {
+          "name": "control_plane_recovery_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "control_plane_recovery_request_idempotency_idx": {
+          "name": "control_plane_recovery_request_idempotency_idx",
+          "columns": [
+            {
+              "expression": "owner_team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "control_plane_recovery_bundles_owner_team_id_teams_id_fk": {
+          "name": "control_plane_recovery_bundles_owner_team_id_teams_id_fk",
+          "tableFrom": "control_plane_recovery_bundles",
+          "tableTo": "teams",
+          "columnsFrom": ["owner_team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "control_plane_recovery_bundles_destination_id_backup_destinations_id_fk": {
+          "name": "control_plane_recovery_bundles_destination_id_backup_destinations_id_fk",
+          "tableFrom": "control_plane_recovery_bundles",
+          "tableTo": "backup_destinations",
+          "columnsFrom": ["destination_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "control_plane_recovery_bundles_requested_by_user_id_users_id_fk": {
+          "name": "control_plane_recovery_bundles_requested_by_user_id_users_id_fk",
+          "tableFrom": "control_plane_recovery_bundles",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "control_plane_recovery_status_check": {
+          "name": "control_plane_recovery_status_check",
+          "value": "\"control_plane_recovery_bundles\".\"status\" IN ('queued', 'running', 'verified', 'failed')"
+        },
+        "control_plane_recovery_format_version_check": {
+          "name": "control_plane_recovery_format_version_check",
+          "value": "\"control_plane_recovery_bundles\".\"format_version\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {
+    "public.environment_variable_revision_seq": {
+      "name": "environment_variable_revision_seq",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1784469525900,
       "tag": "0044_project_shared_environment_variables",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1784472491950,
+      "tag": "0045_huge_human_cannonball",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cli/src/backup-destination-external-import.test.ts
+++ b/packages/cli/src/backup-destination-external-import.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { captureCommandExecution } from "./login-test-helpers";
+import { runCli } from "./program";
+
+const originalHome = process.env.HOME;
+const originalUrl = process.env.DAOFLOW_URL;
+const originalToken = process.env.DAOFLOW_TOKEN;
+const originalFetch = globalThis.fetch;
+
+function responseFor(data: unknown): Response {
+  return new Response(JSON.stringify({ result: { data } }), {
+    headers: { "content-type": "application/json" }
+  });
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+}
+
+describe("backup destination external-import flags", () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "daoflow-destination-import-cli-"));
+    process.env.HOME = homeDir;
+    process.env.DAOFLOW_URL = "https://daoflow.test";
+    process.env.DAOFLOW_TOKEN = "dfl_test_token";
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    if (originalUrl) process.env.DAOFLOW_URL = originalUrl;
+    else delete process.env.DAOFLOW_URL;
+    if (originalToken) process.env.DAOFLOW_TOKEN = originalToken;
+    else delete process.env.DAOFLOW_TOKEN;
+    globalThis.fetch = originalFetch;
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  test("requires an approved prefix when enabling external imports", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(
+        new Error("invalid destination flags must not call the API")
+      )) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "destination",
+        "add",
+        "--name",
+        "archive",
+        "--provider",
+        "s3",
+        "--allow-external-imports",
+        "--dry-run",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: false,
+      error: "--allow-external-imports requires --external-import-prefix.",
+      code: "INVALID_INPUT"
+    });
+  });
+
+  test("destination import dry-run and JSON never expose credentials", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("dry-run must not call the API"))) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "destination",
+        "add",
+        "--name",
+        "archive",
+        "--provider",
+        "s3",
+        "--access-key",
+        "ACCESS_SECRET",
+        "--secret-key",
+        "SECRET_SECRET",
+        "--allow-external-imports",
+        "--external-import-prefix",
+        "database-imports/",
+        "--max-external-import-bytes",
+        "4096",
+        "--dry-run",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBe(3);
+    const output = result.logs[0] ?? "";
+    expect(output).toContain('"externalImportEnabled":true');
+    expect(output).toContain('"externalImportPrefix":"database-imports/"');
+    expect(output).toContain('"maxExternalImportBytes":4096');
+    expect(output).not.toContain("ACCESS_SECRET");
+    expect(output).not.toContain("SECRET_SECRET");
+  });
+
+  test("destination import execution forwards the boundary settings", async () => {
+    let body = "";
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(requestUrl(input)).toContain("/trpc/createBackupDestination");
+      body = typeof init?.body === "string" ? init.body : "";
+      return Promise.resolve(
+        responseFor({
+          id: "dest_123",
+          name: "archive",
+          provider: "s3",
+          accessKey: null,
+          bucket: "backups",
+          region: "us-east-1",
+          endpoint: null,
+          s3Provider: null,
+          rcloneType: null,
+          rcloneRemotePath: null,
+          localPath: null,
+          externalImportEnabled: true,
+          externalImportPrefix: "database-imports/",
+          maxExternalImportBytes: 4096,
+          lastTestedAt: null,
+          lastTestResult: null,
+          createdAt: "2026-07-19T12:00:00.000Z",
+          updatedAt: "2026-07-19T12:00:00.000Z"
+        })
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "destination",
+        "add",
+        "--name",
+        "archive",
+        "--provider",
+        "s3",
+        "--access-key",
+        "ACCESS_SECRET",
+        "--secret-key",
+        "SECRET_SECRET",
+        "--allow-external-imports",
+        "--external-import-prefix",
+        "database-imports/",
+        "--max-external-import-bytes",
+        "4096",
+        "--yes",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBeNull();
+    expect(body).toContain("externalImportEnabled");
+    expect(body).toContain("database-imports/");
+    expect(body).toContain("4096");
+    expect(result.logs.join("\n")).not.toContain("ACCESS_SECRET");
+    expect(result.logs.join("\n")).not.toContain("SECRET_SECRET");
+  });
+});

--- a/packages/cli/src/backup-external.test.ts
+++ b/packages/cli/src/backup-external.test.ts
@@ -1,0 +1,418 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { captureCommandExecution } from "./login-test-helpers";
+import { runCli } from "./program";
+
+const originalHome = process.env.HOME;
+const originalUrl = process.env.DAOFLOW_URL;
+const originalToken = process.env.DAOFLOW_TOKEN;
+const originalFetch = globalThis.fetch;
+
+function responseFor(data: unknown): Response {
+  return new Response(JSON.stringify({ result: { data } }), {
+    headers: { "content-type": "application/json" }
+  });
+}
+
+function scopeDeniedResponse(requiredScope: string): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: `Missing required scope(s): ${requiredScope}`,
+        code: -32003,
+        data: {
+          code: "FORBIDDEN",
+          cause: {
+            code: "SCOPE_DENIED",
+            requiredScopes: [requiredScope],
+            grantedScopes: ["backup:read"]
+          }
+        }
+      }
+    }),
+    { status: 403, headers: { "content-type": "application/json" } }
+  );
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+}
+
+describe("external backup CLI commands", () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "daoflow-external-backup-cli-"));
+    process.env.HOME = homeDir;
+    process.env.DAOFLOW_URL = "https://daoflow.test";
+    process.env.DAOFLOW_TOKEN = "dfl_test_token";
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    if (originalUrl) process.env.DAOFLOW_URL = originalUrl;
+    else delete process.env.DAOFLOW_URL;
+    if (originalToken) process.env.DAOFLOW_TOKEN = originalToken;
+    else delete process.env.DAOFLOW_TOKEN;
+    globalThis.fetch = originalFetch;
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  test("lists external artifacts in the standard JSON envelope", async () => {
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      expect(requestUrl(input)).toContain("/trpc/externalBackupArtifacts");
+      return Promise.resolve(
+        responseFor({
+          artifacts: [
+            {
+              id: "xart_123",
+              destinationId: "dest_123",
+              destinationName: "archive",
+              objectKey: "database-imports/app.dump",
+              objectVersion: "version-1",
+              objectEtag: null,
+              sizeBytes: "4096",
+              sha256: "a".repeat(64),
+              status: "verified",
+              verifiedAt: "2026-07-19T12:00:00.000Z"
+            }
+          ]
+        })
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli(["node", "daoflow", "backup", "external", "list", "--json"]);
+    });
+
+    expect(result.exitCode).toBeNull();
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: true,
+      data: {
+        artifacts: [
+          expect.objectContaining({
+            id: "xart_123",
+            objectKey: "database-imports/app.dump",
+            objectVersion: "version-1",
+            status: "verified"
+          })
+        ]
+      }
+    });
+  });
+
+  test("lists only the approved destination object prefix", async () => {
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      expect(requestUrl(input)).toContain("/trpc/externalBackupObjects");
+      return Promise.resolve(
+        responseFor({
+          destination: { id: "dest_123", name: "archive", provider: "s3" },
+          prefix: "database-imports/daily/",
+          objects: [
+            {
+              key: "database-imports/daily/app.dump",
+              name: "app.dump",
+              size: 2048,
+              lastModified: null,
+              etag: "etag-1",
+              versionId: null
+            }
+          ]
+        })
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "destination",
+        "files",
+        "--id",
+        "dest_123",
+        "--prefix",
+        "daily/",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBeNull();
+    expect(JSON.parse(result.logs[0] ?? "")).toMatchObject({
+      ok: true,
+      data: {
+        prefix: "database-imports/daily/",
+        objects: [{ key: "database-imports/daily/app.dump" }]
+      }
+    });
+  });
+
+  test("human artifact output shows origin, key, pinned identity, size, checksum, and status", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        responseFor({
+          artifacts: [
+            {
+              id: "xart_123",
+              destinationId: "dest_123",
+              destinationName: "archive",
+              objectKey: "database-imports/app.dump",
+              objectVersion: null,
+              objectEtag: "etag-1",
+              sizeBytes: 4096,
+              sha256: "a".repeat(64),
+              status: "verified"
+            }
+          ]
+        })
+      )) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli(["node", "daoflow", "backup", "external", "list"]);
+    });
+
+    const output = result.logs.join("\n");
+    expect(output).toContain("External (archive)");
+    expect(output).toContain("database-imports/app.dump");
+    expect(output).toContain("etag-1");
+    expect(output).toContain("4.0 KB");
+    expect(output).toContain("a".repeat(64));
+    expect(output).toContain("verified");
+  });
+
+  test("register dry-run is local, uses exit code 3, and emits JSON", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("dry-run must not call the API"))) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "external",
+        "register",
+        "--destination",
+        "dest_123",
+        "--object-key",
+        "database-imports/app.dump",
+        "--postgres-major",
+        "17",
+        "--dry-run",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBe(3);
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: true,
+      data: {
+        dryRun: true,
+        destinationId: "dest_123",
+        objectKey: "database-imports/app.dump",
+        postgresMajor: 17
+      }
+    });
+  });
+
+  test("register requires confirmation before mutation", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("confirmation must happen first"))) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "external",
+        "register",
+        "--destination",
+        "dest_123",
+        "--object-key",
+        "database-imports/app.dump",
+        "--postgres-major",
+        "17",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: false,
+      error: "To register external artifact database-imports/app.dump, add --yes",
+      code: "CONFIRMATION_REQUIRED"
+    });
+  });
+
+  test("rejects traversal object keys before any API call", async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error("invalid input must not call the API"))) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "external",
+        "register",
+        "--destination",
+        "dest_123",
+        "--object-key",
+        "../secrets.dump",
+        "--postgres-major",
+        "17",
+        "--dry-run",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: false,
+      error: "Object key cannot include path traversal patterns.",
+      code: "INVALID_INPUT"
+    });
+  });
+
+  test("preserves the required scope in permission errors", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(scopeDeniedResponse("backup:read"))) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli(["node", "daoflow", "backup", "external", "list", "--json"]);
+    });
+
+    expect(result.exitCode).toBe(2);
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: false,
+      error: "Missing required scope(s): backup:read",
+      code: "SCOPE_DENIED",
+      requiredScopes: ["backup:read"],
+      grantedScopes: ["backup:read"]
+    });
+  });
+
+  test("restore dry-run calls the plan route and exits 3", async () => {
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      expect(requestUrl(input)).toContain("/trpc/externalArtifactRestorePlan");
+      return Promise.resolve(
+        responseFor({
+          isReady: true,
+          preflightChecks: [{ status: "ok", detail: "Artifact is verified." }],
+          steps: ["Request approval after review."]
+        })
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "external",
+        "restore",
+        "--artifact-id",
+        "xart_123",
+        "--target-volume",
+        "vol_123",
+        "--dry-run",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBe(3);
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: true,
+      data: {
+        dryRun: true,
+        plan: expect.objectContaining({ isReady: true })
+      }
+    });
+  });
+
+  test("verify execution queues the isolated test restore", async () => {
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      expect(requestUrl(input)).toContain("/trpc/triggerExternalArtifactTestRestore");
+      return Promise.resolve(
+        responseFor({ id: "restore_123", artifactId: "xart_123", status: "queued" })
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "external",
+        "verify",
+        "--artifact-id",
+        "xart_123",
+        "--yes",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBeNull();
+    expect(JSON.parse(result.logs[0] ?? "")).toEqual({
+      ok: true,
+      data: { id: "restore_123", artifactId: "xart_123", status: "queued" }
+    });
+  });
+
+  test("production restore requests approval and never calls a direct restore route", async () => {
+    const urls: string[] = [];
+    let body = "";
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestUrl(input);
+      urls.push(url);
+      body = typeof init?.body === "string" ? init.body : "";
+      expect(url).toContain("/trpc/requestExternalArtifactRestoreApproval");
+      return Promise.resolve(
+        responseFor({
+          id: "apr_123",
+          actionType: "external-artifact-restore",
+          status: "pending",
+          reason: "Restore after an incident"
+        })
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await captureCommandExecution(async () => {
+      await runCli([
+        "node",
+        "daoflow",
+        "backup",
+        "external",
+        "restore",
+        "--artifact-id",
+        "xart_123",
+        "--target-volume",
+        "vol_123",
+        "--yes",
+        "--reason",
+        "Restore after an incident",
+        "--json"
+      ]);
+    });
+
+    expect(result.exitCode).toBeNull();
+    expect(urls).toHaveLength(1);
+    expect(
+      urls.some(
+        (url) => url.includes("restore") && !url.includes("requestExternalArtifactRestoreApproval")
+      )
+    ).toBe(false);
+    expect(body).toContain("xart_123");
+    expect(body).toContain("vol_123");
+    const output = JSON.parse(result.logs[0] ?? "");
+    expect(output).toMatchObject({
+      ok: true,
+      data: {
+        approvalRequested: true,
+        request: { id: "apr_123", actionType: "external-artifact-restore" }
+      }
+    });
+    expect(output.data.nextAction).toContain("different authorized actor");
+  });
+});

--- a/packages/cli/src/commands/backup-destination-commands.ts
+++ b/packages/cli/src/commands/backup-destination-commands.ts
@@ -11,6 +11,12 @@ import {
 } from "../command-helpers";
 import { createClient } from "../trpc-client";
 import { emitBackupDryRunResult, renderBackupError } from "./backup-shared";
+import { registerBackupDestinationFilesCommand } from "./backup-destination-files";
+import {
+  MAX_EXTERNAL_IMPORT_BYTES,
+  normalizeExternalObjectPrefix,
+  parsePositiveInteger
+} from "./backup-external-shared";
 
 export function registerBackupDestinationCommands(backup: Command): void {
   backup
@@ -63,6 +69,8 @@ export function registerBackupDestinationCommands(backup: Command): void {
     .command("destination")
     .description("Manage individual backup destinations");
 
+  registerBackupDestinationFilesCommand(destination);
+
   destination
     .command("add")
     .description("Add a new backup destination")
@@ -80,6 +88,12 @@ export function registerBackupDestinationCommands(backup: Command): void {
     .option("--local-path <path>", "Local filesystem path")
     .option("--rclone-config <config>", "Raw rclone config (INI format)")
     .option("--rclone-remote-path <path>", "Remote path within rclone backend")
+    .option(
+      "--allow-external-imports",
+      "Allow importing PostgreSQL archives from this S3 destination"
+    )
+    .option("--external-import-prefix <prefix>", "Approved S3 object prefix for external imports")
+    .option("--max-external-import-bytes <bytes>", "Maximum external import object size in bytes")
     .option("--json", "Output as JSON")
     .option("--dry-run", "Preview without executing")
     .option("-y, --yes", "Skip confirmation")
@@ -97,6 +111,9 @@ export function registerBackupDestinationCommands(backup: Command): void {
           localPath?: string;
           rcloneConfig?: string;
           rcloneRemotePath?: string;
+          allowExternalImports?: boolean;
+          externalImportPrefix?: string;
+          maxExternalImportBytes?: string;
           json?: boolean;
           dryRun?: boolean;
           yes?: boolean;
@@ -108,16 +125,57 @@ export function registerBackupDestinationCommands(backup: Command): void {
           json: opts.json,
           renderError: renderBackupError,
           action: async (ctx) => {
+            let provider: string;
+            let externalImportPrefix: string | undefined;
+            let maxExternalImportBytes: number | undefined;
+            try {
+              provider = normalizeCliInput(opts.provider, "Destination provider", {
+                allowPathTraversal: true
+              });
+              if (opts.allowExternalImports && provider !== "s3") {
+                throw new Error("External imports can only be enabled for an S3 destination.");
+              }
+              if (!opts.allowExternalImports && opts.externalImportPrefix) {
+                throw new Error("--external-import-prefix requires --allow-external-imports.");
+              }
+              if (!opts.allowExternalImports && opts.maxExternalImportBytes) {
+                throw new Error("--max-external-import-bytes requires --allow-external-imports.");
+              }
+              if (opts.allowExternalImports && !opts.externalImportPrefix) {
+                throw new Error("--allow-external-imports requires --external-import-prefix.");
+              }
+              externalImportPrefix = opts.externalImportPrefix
+                ? normalizeExternalObjectPrefix(opts.externalImportPrefix)
+                : undefined;
+              maxExternalImportBytes = opts.maxExternalImportBytes
+                ? parsePositiveInteger(
+                    opts.maxExternalImportBytes,
+                    "Maximum external import bytes",
+                    {
+                      max: MAX_EXTERNAL_IMPORT_BYTES
+                    }
+                  )
+                : undefined;
+            } catch (error) {
+              return ctx.fail(getErrorMessage(error), { code: "INVALID_INPUT" });
+            }
+
             if (opts.dryRun) {
-              return emitBackupDryRunResult(ctx, {
+              const preview = {
                 dryRun: true,
                 action: "destination.create",
                 name: normalizeCliInput(opts.name, "Destination name"),
-                provider: normalizeCliInput(opts.provider, "Destination provider", {
-                  allowPathTraversal: true
-                }),
-                message: `Would create backup destination "${normalizeCliInput(opts.name, "Destination name")}" (${normalizeCliInput(opts.provider, "Destination provider", { allowPathTraversal: true })})`
-              });
+                provider,
+                message: `Would create backup destination "${normalizeCliInput(opts.name, "Destination name")}" (${provider})`,
+                ...(opts.allowExternalImports
+                  ? {
+                      externalImportEnabled: true,
+                      externalImportPrefix,
+                      ...(maxExternalImportBytes !== undefined ? { maxExternalImportBytes } : {})
+                    }
+                  : {})
+              };
+              return emitBackupDryRunResult(ctx, preview);
             }
 
             ctx.requireConfirmation(
@@ -129,9 +187,8 @@ export function registerBackupDestinationCommands(backup: Command): void {
               const trpc = createClient();
               const result = await trpc.createBackupDestination.mutate({
                 name: normalizeCliInput(opts.name, "Destination name"),
-                provider: normalizeCliInput(opts.provider, "Destination provider", {
-                  allowPathTraversal: true
-                }) as "s3" | "local" | "gdrive" | "onedrive" | "dropbox" | "sftp" | "rclone",
+                provider: provider as
+                  "s3" | "local" | "gdrive" | "onedrive" | "dropbox" | "sftp" | "rclone",
                 accessKey: normalizeOptionalCliInput(opts.accessKey, "Access key", {
                   allowPathTraversal: true,
                   allowShellMetacharacters: true,
@@ -168,7 +225,14 @@ export function registerBackupDestinationCommands(backup: Command): void {
                   {
                     maxLength: 1024
                   }
-                )
+                ),
+                ...(opts.allowExternalImports
+                  ? {
+                      externalImportEnabled: true,
+                      externalImportPrefix,
+                      ...(maxExternalImportBytes !== undefined ? { maxExternalImportBytes } : {})
+                    }
+                  : {})
               });
 
               return ctx.success(result, {

--- a/packages/cli/src/commands/backup-destination-files.ts
+++ b/packages/cli/src/commands/backup-destination-files.ts
@@ -1,0 +1,78 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { runCommandAction } from "../command-action";
+import { getErrorMessage, normalizeCliInput, normalizeOptionalCliInput } from "../command-helpers";
+import { createClient } from "../trpc-client";
+import type { ExternalBackupObjectsOutput } from "../trpc-contract";
+import { renderBackupError } from "./backup-shared";
+import { formatExternalBytes, normalizeExternalObjectPrefix } from "./backup-external-shared";
+
+function renderDestinationFiles(data: ExternalBackupObjectsOutput): void {
+  console.log(chalk.bold("\n  Approved Backup Destination Objects\n"));
+  console.log(`  Destination: ${data.destination.name} (${data.destination.id})`);
+  console.log(`  Approved prefix: ${data.prefix}`);
+
+  if (data.objects.length === 0) {
+    console.log(chalk.dim("  No approved-prefix objects found.\n"));
+    return;
+  }
+
+  for (const object of data.objects) {
+    const identity = object.versionId ?? object.etag ?? "unversioned";
+    console.log(
+      `  ${chalk.bold(object.key)}  ${formatExternalBytes(object.size)}  identity=${chalk.dim(identity)}  modified=${object.lastModified ?? "unknown"}`
+    );
+  }
+  console.log("");
+}
+
+export function registerBackupDestinationFilesCommand(destination: Command): void {
+  destination
+    .command("files")
+    .description("List objects in a destination's approved external-import prefix")
+    .requiredOption("--id <destination>", "Backup destination ID")
+    .option("--prefix <prefix>", "Sub-prefix within the approved import prefix")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Required scope:
+  backup:read
+
+Examples:
+  daoflow backup destination files --id dest_123
+  daoflow backup destination files --id dest_123 --prefix daily/ --json
+
+Example JSON shape:
+  { "ok": true, "data": { "destination": { "id": "dest_123", "name": "archive", "provider": "s3" }, "prefix": "database-imports/", "objects": [{ "key": "database-imports/app.dump", "name": "app.dump", "size": 4096, "lastModified": "2026-07-19T12:00:00.000Z", "etag": "etag-1", "versionId": null }] } }
+`
+    )
+    .action(async (opts: { id: string; prefix?: string; json?: boolean }, command: Command) => {
+      await runCommandAction<ExternalBackupObjectsOutput>({
+        command,
+        json: opts.json,
+        renderError: renderBackupError,
+        action: async (ctx) => {
+          let destinationId: string;
+          let prefix: string | undefined;
+          try {
+            destinationId = normalizeCliInput(opts.id, "Destination ID");
+            prefix = normalizeOptionalCliInput(opts.prefix, "Prefix", { maxLength: 1024 });
+            if (prefix) prefix = normalizeExternalObjectPrefix(prefix);
+          } catch (error) {
+            return ctx.fail(getErrorMessage(error), { code: "INVALID_INPUT" });
+          }
+
+          const trpc = createClient();
+          const data = await trpc.externalBackupObjects.query({
+            destinationId,
+            ...(prefix ? { prefix } : {})
+          });
+
+          return ctx.success(data, {
+            human: () => renderDestinationFiles(data)
+          });
+        }
+      });
+    });
+}

--- a/packages/cli/src/commands/backup-external-commands.ts
+++ b/packages/cli/src/commands/backup-external-commands.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+import { registerExternalArtifactListCommand } from "./backup-external-list";
+import { registerExternalArtifactRegisterCommand } from "./backup-external-register";
+import { registerExternalArtifactRestoreCommands } from "./backup-external-restore";
+
+export function registerBackupExternalCommands(backup: Command): void {
+  const external = backup
+    .command("external")
+    .description("Manage imported external PostgreSQL backup artifacts");
+
+  registerExternalArtifactListCommand(external);
+  registerExternalArtifactRegisterCommand(external);
+  registerExternalArtifactRestoreCommands(external);
+}

--- a/packages/cli/src/commands/backup-external-list.ts
+++ b/packages/cli/src/commands/backup-external-list.ts
@@ -1,0 +1,90 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { runCommandAction } from "../command-action";
+import { getErrorMessage, normalizeCliInput } from "../command-helpers";
+import { createClient } from "../trpc-client";
+import type { ExternalBackupArtifactsOutput } from "../trpc-contract";
+import { renderBackupError } from "./backup-shared";
+import {
+  formatExternalBytes,
+  pinnedExternalIdentity,
+  renderExternalStatus,
+  parsePositiveInteger
+} from "./backup-external-shared";
+
+function renderExternalArtifacts(data: ExternalBackupArtifactsOutput): void {
+  console.log(chalk.bold("\n  External Backup Artifacts\n"));
+  if (data.artifacts.length === 0) {
+    console.log(chalk.dim("  No external artifacts registered.\n"));
+    return;
+  }
+
+  for (const artifact of data.artifacts) {
+    const origin = artifact.destinationName
+      ? `External (${artifact.destinationName})`
+      : `External (${artifact.destinationId})`;
+    console.log(`  ${chalk.bold(origin)}  ${renderExternalStatus(artifact.status)}`);
+    console.log(`    ID:       ${artifact.id}`);
+    console.log(`    Key:      ${artifact.objectKey}`);
+    console.log(
+      `    Pinned:   ${pinnedExternalIdentity(artifact.objectVersion, artifact.objectEtag)}`
+    );
+    console.log(`    Size:     ${formatExternalBytes(artifact.sizeBytes)}`);
+    console.log(`    Checksum: ${artifact.sha256 ?? "pending"}`);
+    console.log();
+  }
+}
+
+export function registerExternalArtifactListCommand(external: Command): void {
+  external
+    .command("list")
+    .description("List registered external backup artifacts")
+    .option("--destination <id>", "Filter by backup destination ID")
+    .option("--limit <n>", "Maximum artifacts to show", "50")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Required scope:
+  backup:read
+
+Examples:
+  daoflow backup external list
+  daoflow backup external list --destination dest_123 --limit 20 --json
+
+Example JSON shape:
+  { "ok": true, "data": { "artifacts": [{ "id": "xart_123", "destinationId": "dest_123", "destinationName": "archive", "objectKey": "database-imports/app.dump", "objectVersion": "v1", "objectEtag": null, "sizeBytes": "4096", "sha256": "...", "status": "verified", "verifiedAt": "2026-07-19T12:00:00.000Z" }] } }
+`
+    )
+    .action(
+      async (opts: { destination?: string; limit: string; json?: boolean }, command: Command) => {
+        await runCommandAction<ExternalBackupArtifactsOutput>({
+          command,
+          json: opts.json,
+          renderError: renderBackupError,
+          action: async (ctx) => {
+            let destinationId: string | undefined;
+            let limit: number;
+            try {
+              destinationId = opts.destination
+                ? normalizeCliInput(opts.destination, "Destination ID")
+                : undefined;
+              limit = parsePositiveInteger(opts.limit, "Limit", { max: 100 });
+            } catch (error) {
+              return ctx.fail(getErrorMessage(error), { code: "INVALID_INPUT" });
+            }
+
+            const trpc = createClient();
+            const data = await trpc.externalBackupArtifacts.query({
+              ...(destinationId ? { destinationId } : {}),
+              limit
+            });
+
+            return ctx.success(data, {
+              human: () => renderExternalArtifacts(data)
+            });
+          }
+        });
+      }
+    );
+}

--- a/packages/cli/src/commands/backup-external-register.ts
+++ b/packages/cli/src/commands/backup-external-register.ts
@@ -1,0 +1,118 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { runCommandAction } from "../command-action";
+import { getErrorMessage, normalizeCliInput } from "../command-helpers";
+import { createClient } from "../trpc-client";
+import { renderBackupError } from "./backup-shared";
+import {
+  normalizeExternalObjectKey,
+  parsePositiveInteger,
+  validateSafetyFlags
+} from "./backup-external-shared";
+
+export function registerExternalArtifactRegisterCommand(external: Command): void {
+  external
+    .command("register")
+    .description("Register an exact object as an external PostgreSQL backup artifact")
+    .requiredOption("--destination <id>", "Backup destination ID")
+    .requiredOption("--object-key <key>", "Exact approved-prefix object key")
+    .requiredOption("--postgres-major <n>", "Expected PostgreSQL major version")
+    .option("--dry-run", "Preview locally without making an API call")
+    .option("-y, --yes", "Execute the registration")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Required scope:
+  execution: backup:restore
+
+Examples:
+  daoflow backup external register --destination dest_123 --object-key database-imports/app.dump --postgres-major 17 --dry-run --json
+  daoflow backup external register --destination dest_123 --object-key database-imports/app.dump --postgres-major 17 --yes
+
+Example JSON shape:
+  { "ok": true, "data": { "artifact": { "id": "xart_123", "objectKey": "database-imports/app.dump", "status": "registering" }, "workflowId": "external-import-xart_123", "nextAction": "Wait for isolated archive inspection." } }
+`
+    )
+    .action(
+      async (
+        opts: {
+          destination: string;
+          objectKey: string;
+          postgresMajor: string;
+          dryRun?: boolean;
+          yes?: boolean;
+          json?: boolean;
+        },
+        command: Command
+      ) => {
+        await runCommandAction<unknown>({
+          command,
+          json: opts.json,
+          renderError: renderBackupError,
+          action: async (ctx) => {
+            let destinationId: string;
+            let objectKey: string;
+            let postgresMajor: number;
+            try {
+              destinationId = normalizeCliInput(opts.destination, "Destination ID");
+              objectKey = normalizeExternalObjectKey(opts.objectKey);
+              postgresMajor = parsePositiveInteger(opts.postgresMajor, "PostgreSQL major", {
+                max: 99
+              });
+              validateSafetyFlags(opts.dryRun, opts.yes);
+            } catch (error) {
+              return ctx.fail(getErrorMessage(error), { code: "INVALID_INPUT" });
+            }
+
+            if (opts.dryRun) {
+              return ctx.dryRun(
+                {
+                  dryRun: true,
+                  destinationId,
+                  objectKey,
+                  postgresMajor
+                },
+                {
+                  json: {
+                    ok: true,
+                    data: { dryRun: true, destinationId, objectKey, postgresMajor }
+                  },
+                  human: () => {
+                    console.log(chalk.bold("\n  External Artifact Registration (dry-run)\n"));
+                    console.log(`  Destination: ${destinationId}`);
+                    console.log(`  Object key:  ${objectKey}`);
+                    console.log(`  PostgreSQL:  ${postgresMajor}`);
+                    console.log(chalk.dim("  No API mutation was made.\n"));
+                  }
+                }
+              );
+            }
+
+            ctx.requireConfirmation(
+              opts.yes === true,
+              `To register external artifact ${objectKey}, add --yes`
+            );
+
+            const trpc = createClient();
+            const result = await trpc.registerExternalBackupArtifact.mutate({
+              destinationId,
+              objectKey,
+              postgresMajor
+            });
+
+            return ctx.success(result, {
+              quiet: () => result.artifact.id,
+              human: () => {
+                console.log(
+                  chalk.green(`✅ External artifact registration queued: ${result.artifact.id}`)
+                );
+                console.log(`  Workflow: ${result.workflowId}`);
+                console.log(`  Next: ${result.nextAction}`);
+              }
+            });
+          }
+        });
+      }
+    );
+}

--- a/packages/cli/src/commands/backup-external-restore.ts
+++ b/packages/cli/src/commands/backup-external-restore.ts
@@ -1,0 +1,216 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { runCommandAction } from "../command-action";
+import { getErrorMessage, normalizeCliInput, normalizeOptionalCliInput } from "../command-helpers";
+import { createClient } from "../trpc-client";
+import type {
+  ExternalArtifactRestorePlanOutput,
+  ApprovalQueueRequestOutput
+} from "../trpc-contract";
+import { renderBackupError } from "./backup-shared";
+import { DEFAULT_EXTERNAL_RESTORE_REASON, validateSafetyFlags } from "./backup-external-shared";
+
+function renderPlan(plan: ExternalArtifactRestorePlanOutput): void {
+  console.log(chalk.bold("\n  External Artifact Restore Plan (dry-run)\n"));
+  if (typeof plan.isReady === "boolean") console.log(`  Ready: ${plan.isReady ? "yes" : "no"}`);
+
+  if (plan.preflightChecks?.length) {
+    console.log(chalk.dim("  Preflight checks:"));
+    for (const check of plan.preflightChecks) {
+      const marker = check.status === "ok" ? chalk.green("✓") : chalk.yellow("!");
+      console.log(`    ${marker} ${check.detail}`);
+    }
+  }
+
+  if (plan.steps?.length) {
+    console.log(chalk.dim("  Steps:"));
+    plan.steps.forEach((step, index) => console.log(`    ${index + 1}. ${step}`));
+  }
+
+  console.log(
+    chalk.dim(
+      "  Production restore is approval-only; this preview never queues a restore directly.\n"
+    )
+  );
+}
+
+function renderApprovalRequest(request: ApprovalQueueRequestOutput): void {
+  console.log(chalk.green(`✅ Approval requested: ${request.id}`));
+  console.log(`  Status: ${request.status}`);
+  console.log(
+    chalk.yellow(
+      "  A different authorized actor must approve this request before any production restore can run."
+    )
+  );
+}
+
+export function registerExternalArtifactRestoreCommands(external: Command): void {
+  external
+    .command("verify")
+    .description("Queue an isolated test restore for an external artifact")
+    .requiredOption("--artifact-id <id>", "External artifact ID")
+    .option("--dry-run", "Preview locally without making an API call")
+    .option("-y, --yes", "Queue the isolated verification")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Required scope:
+  execution: backup:restore
+
+Examples:
+  daoflow backup external verify --artifact-id xart_123 --dry-run --json
+  daoflow backup external verify --artifact-id xart_123 --yes
+
+Example JSON shape:
+  { "ok": true, "data": { "id": "restore_123", "artifactId": "xart_123", "status": "queued" } }
+`
+    )
+    .action(
+      async (
+        opts: { artifactId: string; dryRun?: boolean; yes?: boolean; json?: boolean },
+        command: Command
+      ) => {
+        await runCommandAction<unknown>({
+          command,
+          json: opts.json,
+          renderError: renderBackupError,
+          action: async (ctx) => {
+            let artifactId: string;
+            try {
+              artifactId = normalizeCliInput(opts.artifactId, "Artifact ID");
+              validateSafetyFlags(opts.dryRun, opts.yes);
+            } catch (error) {
+              return ctx.fail(getErrorMessage(error), { code: "INVALID_INPUT" });
+            }
+
+            if (opts.dryRun) {
+              return ctx.dryRun(
+                { dryRun: true, artifactId, action: "external-artifact-test-restore" },
+                {
+                  json: {
+                    ok: true,
+                    data: { dryRun: true, artifactId, action: "external-artifact-test-restore" }
+                  },
+                  human: () => {
+                    console.log(chalk.bold("\n  External Artifact Verification (dry-run)\n"));
+                    console.log(`  Artifact: ${artifactId}`);
+                    console.log(chalk.dim("  No API mutation was made.\n"));
+                  }
+                }
+              );
+            }
+
+            ctx.requireConfirmation(
+              opts.yes === true,
+              `To queue isolated verification for ${artifactId}, add --yes`
+            );
+
+            const trpc = createClient();
+            const result = await trpc.triggerExternalArtifactTestRestore.mutate({ artifactId });
+            return ctx.success(result, {
+              quiet: () => result.id,
+              human: () =>
+                console.log(chalk.green(`✅ External artifact verification queued: ${result.id}`))
+            });
+          }
+        });
+      }
+    );
+
+  external
+    .command("restore")
+    .description("Request approval to restore an external artifact to a target volume")
+    .requiredOption("--artifact-id <id>", "External artifact ID")
+    .requiredOption("--target-volume <id>", "Target PostgreSQL volume ID")
+    .option("--dry-run", "Preview the server restore plan")
+    .option("-y, --yes", "Request production restore approval")
+    .option("--reason <text>", "Reason for the approval request")
+    .option("--json", "Output as JSON")
+    .addHelpText(
+      "after",
+      `
+Required scopes:
+  dry-run: backup:read
+  execution: approvals:create, backup:restore
+
+Examples:
+  daoflow backup external restore --artifact-id xart_123 --target-volume vol_123 --dry-run --json
+  daoflow backup external restore --artifact-id xart_123 --target-volume vol_123 --yes --reason "Restore after an incident"
+
+Example JSON shapes:
+  { "ok": true, "data": { "dryRun": true, "plan": { "isReady": true, "steps": ["Validate artifact"] } } }
+  { "ok": true, "data": { "approvalRequested": true, "request": { "id": "apr_123", "actionType": "external-artifact-restore", "status": "pending" }, "nextAction": "A different authorized actor must approve this request before any production restore can run." } }
+`
+    )
+    .action(
+      async (
+        opts: {
+          artifactId: string;
+          targetVolume: string;
+          dryRun?: boolean;
+          yes?: boolean;
+          reason?: string;
+          json?: boolean;
+        },
+        command: Command
+      ) => {
+        await runCommandAction<unknown>({
+          command,
+          json: opts.json,
+          renderError: renderBackupError,
+          action: async (ctx) => {
+            let artifactId: string;
+            let targetVolumeId: string;
+            let reason: string;
+            try {
+              artifactId = normalizeCliInput(opts.artifactId, "Artifact ID");
+              targetVolumeId = normalizeCliInput(opts.targetVolume, "Target volume ID");
+              reason =
+                normalizeOptionalCliInput(opts.reason, "Reason", { maxLength: 1000 }) ??
+                DEFAULT_EXTERNAL_RESTORE_REASON;
+              validateSafetyFlags(opts.dryRun, opts.yes);
+            } catch (error) {
+              return ctx.fail(getErrorMessage(error), { code: "INVALID_INPUT" });
+            }
+
+            if (opts.dryRun) {
+              const trpc = createClient();
+              const plan = await trpc.externalArtifactRestorePlan.query({
+                artifactId,
+                targetVolumeId
+              });
+              return ctx.dryRun(
+                { dryRun: true, plan },
+                {
+                  json: { ok: true, data: { dryRun: true, plan } },
+                  human: () => renderPlan(plan)
+                }
+              );
+            }
+
+            ctx.requireConfirmation(
+              opts.yes === true,
+              `To request production restore approval for ${artifactId}, add --yes`
+            );
+
+            const trpc = createClient();
+            const request = await trpc.requestExternalArtifactRestoreApproval.mutate({
+              artifactId,
+              targetVolumeId,
+              reason
+            });
+            const nextAction =
+              "A different authorized actor must approve this request before any production restore can run.";
+            return ctx.success(
+              { approvalRequested: true, request, nextAction },
+              {
+                quiet: () => request.id,
+                human: () => renderApprovalRequest(request)
+              }
+            );
+          }
+        });
+      }
+    );
+}

--- a/packages/cli/src/commands/backup-external-shared.ts
+++ b/packages/cli/src/commands/backup-external-shared.ts
@@ -1,0 +1,87 @@
+import chalk from "chalk";
+import { normalizeCliInput } from "../command-helpers";
+
+export const DEFAULT_EXTERNAL_RESTORE_REASON =
+  "Request an approved restore of a verified external PostgreSQL artifact.";
+export const MAX_EXTERNAL_IMPORT_BYTES = 2 * 1024 * 1024 * 1024;
+
+export function normalizeExternalObjectKey(value: string, field = "Object key"): string {
+  const key = normalizeCliInput(value, field, { maxLength: 1024 });
+  const parts = key.split("/");
+  if (
+    key.startsWith("/") ||
+    key.includes("\\") ||
+    parts.some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(`${field} must be a relative object key without traversal segments.`);
+  }
+
+  return key;
+}
+
+export function normalizeExternalObjectPrefix(value: string): string {
+  const prefix = normalizeCliInput(value, "External import prefix", { maxLength: 1024 });
+  const withoutTrailingSlash = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+  if (!withoutTrailingSlash) {
+    throw new Error("External import prefix must contain at least one path segment.");
+  }
+
+  normalizeExternalObjectKey(withoutTrailingSlash, "External import prefix");
+  return `${withoutTrailingSlash}/`;
+}
+
+export function parsePositiveInteger(
+  value: string,
+  field: string,
+  options?: { max?: number }
+): number {
+  const normalized = normalizeCliInput(value, field, {
+    allowPathTraversal: true,
+    maxLength: 20
+  });
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`${field} must be a positive integer.`);
+  }
+
+  const parsed = Number(normalized);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    (options?.max !== undefined && parsed > options.max)
+  ) {
+    const suffix = options?.max === undefined ? "" : ` no greater than ${options.max}`;
+    throw new Error(`${field} must be a positive integer${suffix}.`);
+  }
+
+  return parsed;
+}
+
+export function formatExternalBytes(value: number | string | null | undefined): string {
+  const bytes = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(bytes) || bytes < 0) return "unknown";
+  if (bytes === 0) return "0 B";
+
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const unitIndex = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** unitIndex).toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+export function pinnedExternalIdentity(
+  objectVersion: string | null | undefined,
+  objectEtag: string | null | undefined
+): string {
+  return objectVersion ?? objectEtag ?? "unavailable";
+}
+
+export function renderExternalStatus(status: string): string {
+  if (status === "verified" || status === "registered") return chalk.green(status);
+  if (status === "failed") return chalk.red(status);
+  if (status === "verifying" || status === "registering") return chalk.yellow(status);
+  return chalk.dim(status);
+}
+
+export function validateSafetyFlags(dryRun: boolean | undefined, yes: boolean | undefined): void {
+  if (dryRun && yes) {
+    throw new Error("Use either --dry-run or --yes, not both.");
+  }
+}

--- a/packages/cli/src/commands/backup.ts
+++ b/packages/cli/src/commands/backup.ts
@@ -22,6 +22,7 @@ import {
   renderBackupVerificationInfo
 } from "./backup-download";
 import { registerBackupDestinationCommands } from "./backup-destination-commands";
+import { registerBackupExternalCommands } from "./backup-external-commands";
 import { registerBackupPolicySubcommands } from "./backup-policy";
 import { registerBackupScheduleCommands } from "./backup-schedule-commands";
 import { registerControlPlaneRecoveryCommands } from "./control-plane-recovery";
@@ -42,6 +43,7 @@ export function backupCommand(): Command {
   const backup = new Command("backup").description("Manage backup policies and runs");
   registerBackupPolicySubcommands(backup);
   registerBackupDestinationCommands(backup);
+  registerBackupExternalCommands(backup);
   registerBackupScheduleCommands(backup);
   registerControlPlaneRecoveryCommands(backup);
 

--- a/packages/cli/src/trpc-contract.ts
+++ b/packages/cli/src/trpc-contract.ts
@@ -217,7 +217,8 @@ export interface AccessLogsOutput {
 
 export interface ApprovalQueueRequestOutput {
   id: string;
-  actionType: "compose-release" | "backup-restore" | "preview-deployment";
+  actionType:
+    "compose-release" | "backup-restore" | "preview-deployment" | "external-artifact-restore";
   targetResource: string;
   reason: string;
   status: string;
@@ -454,10 +455,90 @@ export interface BackupDestinationOutput {
   rcloneType: string | null;
   rcloneRemotePath: string | null;
   localPath: string | null;
+  externalImportEnabled?: boolean;
+  externalImportPrefix?: string | null;
+  maxExternalImportBytes?: number | string | null;
   lastTestedAt: string | null;
   lastTestResult: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ExternalBackupObjectOutput {
+  key: string;
+  name: string;
+  size: number;
+  lastModified: string | null;
+  etag: string | null;
+  versionId: string | null;
+}
+
+export interface ExternalBackupObjectsOutput {
+  destination: {
+    id: string;
+    name: string;
+    provider: string;
+    externalImportEnabled?: boolean;
+    externalImportPrefix?: string | null;
+    maxExternalImportBytes?: number | string | null;
+  };
+  prefix: string;
+  objects: ExternalBackupObjectOutput[];
+}
+
+export type ExternalBackupArtifactStatus =
+  "registering" | "registered" | "verifying" | "verified" | "failed";
+
+export interface ExternalBackupArtifactOutput {
+  id: string;
+  destinationId: string;
+  destinationName?: string;
+  objectKey: string;
+  objectVersion: string | null;
+  objectEtag: string | null;
+  sizeBytes: number | string;
+  contentType?: string | null;
+  lastModified?: string | null;
+  sha256: string | null;
+  archiveFormat?: string | null;
+  sourcePostgresVersion?: string | null;
+  databaseEngineVersion?: string | null;
+  verifierImage?: string | null;
+  status: ExternalBackupArtifactStatus;
+  registerError?: string | null;
+  error?: string | null;
+  registeredAt?: string | null;
+  verifiedAt?: string | null;
+  latestVerification?: Record<string, unknown> | null;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface ExternalBackupArtifactsOutput {
+  artifacts: ExternalBackupArtifactOutput[];
+}
+
+export interface RegisterExternalBackupArtifactOutput {
+  artifact: ExternalBackupArtifactOutput;
+  workflowId: string;
+  nextAction: string;
+}
+
+export interface ExternalArtifactRestoreQueueOutput {
+  id: string;
+  artifactId: string;
+  status: string;
+}
+
+export interface ExternalArtifactRestorePlanOutput {
+  isReady?: boolean;
+  artifact?: ExternalBackupArtifactOutput | Record<string, unknown>;
+  target?: Record<string, unknown>;
+  preflightChecks?: Array<{ status: string; detail: string }>;
+  steps?: string[];
+  executeCommand?: string;
+  approvalRequest?: Record<string, unknown>;
+  [key: string]: unknown;
 }
 
 export interface QueueRestoreOutput {
@@ -1641,6 +1722,18 @@ export interface DaoFlowTRPC {
   backupRunDetails: QueryProcedure<BackupRunDetailsOutput, { runId: string }>;
   persistentVolumes: QueryProcedure<PersistentVolumeRegistryOutput, { limit?: number }>;
   backupDestinations: QueryProcedure<BackupDestinationOutput[], { limit?: number }>;
+  externalBackupObjects: QueryProcedure<
+    ExternalBackupObjectsOutput,
+    { destinationId: string; prefix?: string }
+  >;
+  externalBackupArtifacts: QueryProcedure<
+    ExternalBackupArtifactsOutput,
+    {
+      destinationId?: string;
+      limit?: number;
+    }
+  >;
+  externalBackupArtifact: QueryProcedure<ExternalBackupArtifactOutput, { artifactId: string }>;
   createVolume: MutationProcedure<
     {
       name: string;
@@ -1682,6 +1775,9 @@ export interface DaoFlowTRPC {
       rcloneRemotePath?: string;
       oauthToken?: string;
       localPath?: string;
+      externalImportEnabled?: boolean;
+      externalImportPrefix?: string;
+      maxExternalImportBytes?: number;
     },
     BackupDestinationOutput
   >;
@@ -1737,6 +1833,22 @@ export interface DaoFlowTRPC {
   triggerTestRestore: MutationProcedure<{ backupRunId: string }, QueueRestoreOutput>;
   backupRestorePlan: QueryProcedure<BackupRestorePlanOutput, { backupRunId: string }>;
   queueBackupRestore: MutationProcedure<{ backupRunId: string }, QueueRestoreOutput>;
+  registerExternalBackupArtifact: MutationProcedure<
+    { destinationId: string; objectKey: string; postgresMajor: number },
+    RegisterExternalBackupArtifactOutput
+  >;
+  triggerExternalArtifactTestRestore: MutationProcedure<
+    { artifactId: string },
+    ExternalArtifactRestoreQueueOutput
+  >;
+  externalArtifactRestorePlan: QueryProcedure<
+    ExternalArtifactRestorePlanOutput,
+    { artifactId: string; targetVolumeId: string }
+  >;
+  requestExternalArtifactRestoreApproval: MutationProcedure<
+    { artifactId: string; targetVolumeId: string; reason: string },
+    ApprovalQueueRequestOutput
+  >;
   controlPlaneRecoveryPlan: QueryProcedure<
     ControlPlaneRecoveryPlanOutput,
     { destinationId: string }

--- a/packages/client/src/components/AddDestinationDialog.test.tsx
+++ b/packages/client/src/components/AddDestinationDialog.test.tsx
@@ -68,8 +68,34 @@ describe("AddDestinationDialog", () => {
       localPath: undefined,
       rcloneConfig: undefined,
       rcloneRemotePath: undefined,
-      oauthToken: undefined
+      oauthToken: undefined,
+      externalImportEnabled: false,
+      externalImportPrefix: undefined,
+      maxExternalImportBytes: undefined
     });
+  });
+
+  it("requires an explicit S3 import boundary before enabling external archives", () => {
+    const { onSubmit } = renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "approved-imports" } });
+    fireEvent.click(screen.getByTestId("destination-external-import-enabled"));
+    fireEvent.change(screen.getByLabelText("Approved prefix"), {
+      target: { value: "database-imports/" }
+    });
+    fireEvent.change(screen.getByLabelText("Maximum bytes"), {
+      target: { value: "1073741824" }
+    });
+    fireEvent.click(screen.getByTestId("destination-create-button"));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "s3",
+        externalImportEnabled: true,
+        externalImportPrefix: "database-imports/",
+        maxExternalImportBytes: 1_073_741_824
+      })
+    );
   });
 
   it("keeps a manually entered name when the provider changes", () => {
@@ -109,7 +135,10 @@ describe("AddDestinationDialog", () => {
       localPath: undefined,
       rcloneConfig: undefined,
       rcloneRemotePath: undefined,
-      oauthToken: '{"access_token":"token"}'
+      oauthToken: '{"access_token":"token"}',
+      externalImportEnabled: undefined,
+      externalImportPrefix: undefined,
+      maxExternalImportBytes: undefined
     });
   });
 
@@ -136,7 +165,10 @@ describe("AddDestinationDialog", () => {
       localPath: "/srv/backups",
       rcloneConfig: undefined,
       rcloneRemotePath: undefined,
-      oauthToken: undefined
+      oauthToken: undefined,
+      externalImportEnabled: undefined,
+      externalImportPrefix: undefined,
+      maxExternalImportBytes: undefined
     });
   });
 
@@ -169,7 +201,10 @@ describe("AddDestinationDialog", () => {
       localPath: undefined,
       rcloneConfig: "[remote]\ntype = sftp\nhost = backup.example.com",
       rcloneRemotePath: "backups/daoflow",
-      oauthToken: undefined
+      oauthToken: undefined,
+      externalImportEnabled: undefined,
+      externalImportPrefix: undefined,
+      maxExternalImportBytes: undefined
     });
   });
 });

--- a/packages/client/src/components/AddDestinationDialog.tsx
+++ b/packages/client/src/components/AddDestinationDialog.tsx
@@ -53,9 +53,12 @@ export function AddDestinationDialog({
   const [form, setForm] = useState(createInitialAddDestinationFormState);
   const [copied, setCopied] = useState(false);
 
-  const updateField = useCallback((field: keyof AddDestinationFormState, value: string) => {
-    setForm((current) => ({ ...current, [field]: value }));
-  }, []);
+  const updateField = useCallback(
+    (field: keyof AddDestinationFormState, value: string | boolean) => {
+      setForm((current) => ({ ...current, [field]: value }));
+    },
+    []
+  );
 
   const handleProviderChange = useCallback((v: string) => {
     const key = v as ProviderKey;

--- a/packages/client/src/components/DestinationsTable.tsx
+++ b/packages/client/src/components/DestinationsTable.tsx
@@ -22,6 +22,8 @@ interface Destination {
   rcloneRemotePath?: string | null;
   lastTestResult?: string | null;
   lastTestedAt?: string | null;
+  externalImportEnabled?: boolean;
+  externalImportPrefix?: string | null;
 }
 
 interface DestinationsTableProps {
@@ -64,11 +66,18 @@ export function DestinationsTable({
                   <Badge variant="secondary">{d.provider}</Badge>
                 </TableCell>
                 <TableCell className="text-muted-foreground text-sm">
-                  {d.provider === "s3"
-                    ? `${d.bucket ?? ""}${d.region ? ` (${d.region})` : ""}`
-                    : d.provider === "local"
-                      ? (d.localPath ?? "")
-                      : (d.rcloneRemotePath ?? "—")}
+                  <div>
+                    {d.provider === "s3"
+                      ? `${d.bucket ?? ""}${d.region ? ` (${d.region})` : ""}`
+                      : d.provider === "local"
+                        ? (d.localPath ?? "")
+                        : (d.rcloneRemotePath ?? "—")}
+                  </div>
+                  {d.externalImportEnabled ? (
+                    <div className="mt-1 text-xs text-primary">
+                      Imports: /{d.externalImportPrefix}
+                    </div>
+                  ) : null}
                 </TableCell>
                 <TableCell>
                   {d.lastTestResult === "success" ? (

--- a/packages/client/src/components/backups/ExternalArchiveImportCard.test.tsx
+++ b/packages/client/src/components/backups/ExternalArchiveImportCard.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExternalArchiveImportCard } from "./ExternalArchiveImportCard";
+
+const { objectsUseQueryMock, registerUseMutationMock } = vi.hoisted(() => ({
+  objectsUseQueryMock: vi.fn(),
+  registerUseMutationMock: vi.fn()
+}));
+
+vi.mock("@/lib/trpc", () => ({
+  trpc: {
+    externalBackupObjects: { useQuery: objectsUseQueryMock },
+    registerExternalBackupArtifact: { useMutation: registerUseMutationMock }
+  }
+}));
+
+describe("ExternalArchiveImportCard", () => {
+  beforeEach(() => {
+    objectsUseQueryMock.mockReturnValue({ data: { objects: [] } });
+    registerUseMutationMock.mockReturnValue({ isPending: false, mutateAsync: vi.fn() });
+  });
+
+  afterEach(cleanup);
+
+  it("keeps external imports disabled until the destination has an approved boundary", () => {
+    render(
+      <MemoryRouter>
+        <ExternalArchiveImportCard
+          destinationId="dest_1"
+          enabled={false}
+          approvedPrefix={null}
+          maxBytes={2_147_483_648}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/imports are disabled for this destination/i)).toBeVisible();
+    expect(objectsUseQueryMock).toHaveBeenCalledWith(
+      { destinationId: "dest_1" },
+      { enabled: false }
+    );
+  });
+
+  it("registers an exact key with the declared PostgreSQL major", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({
+      artifact: { id: "xba_1" },
+      workflowId: "external-import-xba_1",
+      nextAction: "test-restore"
+    });
+    registerUseMutationMock.mockReturnValue({ isPending: false, mutateAsync });
+
+    render(
+      <MemoryRouter>
+        <ExternalArchiveImportCard
+          destinationId="dest_1"
+          enabled={true}
+          approvedPrefix="database-imports/"
+          maxBytes={2_147_483_648}
+        />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByTestId("external-archive-key"), {
+      target: { value: "database-imports/customer.dump" }
+    });
+    fireEvent.change(screen.getByTestId("external-archive-postgres-major"), {
+      target: { value: "16" }
+    });
+    fireEvent.click(screen.getByTestId("external-archive-register"));
+
+    await waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        destinationId: "dest_1",
+        objectKey: "database-imports/customer.dump",
+        postgresMajor: 16
+      })
+    );
+    expect(screen.getByTestId("external-archive-feedback")).toHaveTextContent("Registered xba_1");
+  });
+});

--- a/packages/client/src/components/backups/ExternalArchiveImportCard.tsx
+++ b/packages/client/src/components/backups/ExternalArchiveImportCard.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { isTRPCClientError } from "@trpc/client";
+import { DatabaseBackup } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { trpc } from "@/lib/trpc";
+import { formatBytes } from "@/lib/tone-utils";
+
+interface ExternalArchiveImportCardProps {
+  destinationId: string;
+  enabled: boolean;
+  approvedPrefix: string | null;
+  maxBytes: number;
+}
+
+export function ExternalArchiveImportCard({
+  destinationId,
+  enabled,
+  approvedPrefix,
+  maxBytes
+}: ExternalArchiveImportCardProps) {
+  const [objectKey, setObjectKey] = useState("");
+  const [postgresMajor, setPostgresMajor] = useState("17");
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const objects = trpc.externalBackupObjects.useQuery(
+    { destinationId },
+    { enabled: Boolean(destinationId) && enabled }
+  );
+  const registerArtifact = trpc.registerExternalBackupArtifact.useMutation();
+
+  async function registerObject(key: string) {
+    setFeedback(null);
+    try {
+      const result = await registerArtifact.mutateAsync({
+        destinationId,
+        objectKey: key,
+        postgresMajor: Number(postgresMajor)
+      });
+      setObjectKey(key);
+      setFeedback(
+        `Registered ${result.artifact.id}. Validation is running before test restore becomes available.`
+      );
+    } catch (error) {
+      setFeedback(
+        isTRPCClientError(error) ? error.message : "Unable to register this PostgreSQL archive."
+      );
+    }
+  }
+
+  return (
+    <Card data-testid="external-archive-import-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <DatabaseBackup size={17} /> Import an existing PostgreSQL archive
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          DaoFlow pins the exact S3 object, streams and inspects the custom-format archive, then
+          requires an isolated test restore before production approval.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!enabled ? (
+          <p className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-muted-foreground">
+            Existing archive imports are disabled for this destination. Create or update an S3
+            destination with an approved import prefix first.
+          </p>
+        ) : (
+          <>
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_9rem_auto] sm:items-end">
+              <div className="grid gap-1.5">
+                <Label htmlFor="external-archive-key">Exact object key</Label>
+                <Input
+                  id="external-archive-key"
+                  data-testid="external-archive-key"
+                  placeholder={approvedPrefix ?? "database-imports/db.dump"}
+                  value={objectKey}
+                  onChange={(event) => setObjectKey(event.target.value)}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="external-archive-postgres-major">PostgreSQL major</Label>
+                <Input
+                  id="external-archive-postgres-major"
+                  data-testid="external-archive-postgres-major"
+                  inputMode="numeric"
+                  value={postgresMajor}
+                  onChange={(event) => setPostgresMajor(event.target.value)}
+                />
+              </div>
+              <Button
+                data-testid="external-archive-register"
+                disabled={
+                  registerArtifact.isPending ||
+                  objectKey.trim().length === 0 ||
+                  !/^\d+$/.test(postgresMajor)
+                }
+                onClick={() => void registerObject(objectKey.trim())}
+              >
+                {registerArtifact.isPending ? "Registering…" : "Register archive"}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Approved prefix: /{approvedPrefix} · Maximum size: {formatBytes(maxBytes)}
+            </p>
+            {objects.data?.objects.length ? (
+              <div className="space-y-2 rounded-md border p-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Objects under the approved prefix
+                </p>
+                {objects.data.objects.slice(0, 12).map((object) => (
+                  <div
+                    className="flex items-center justify-between gap-3 text-sm"
+                    key={`${object.key}:${object.versionId ?? object.etag}`}
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate font-medium" title={object.key}>
+                        {object.name}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {formatBytes(object.size)} ·{" "}
+                        {object.lastModified
+                          ? new Date(object.lastModified).toLocaleString()
+                          : "Modified time unavailable"}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={registerArtifact.isPending}
+                      data-testid={`external-archive-select-${object.key}`}
+                      onClick={() => {
+                        setObjectKey(object.key);
+                        void registerObject(object.key);
+                      }}
+                    >
+                      Import
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </>
+        )}
+        {feedback ? (
+          <p
+            className="rounded-md border bg-muted px-3 py-2 text-sm"
+            data-testid="external-archive-feedback"
+          >
+            {feedback}{" "}
+            {feedback.startsWith("Registered") ? (
+              <Link className="font-medium text-primary hover:underline" to="/backups">
+                View external archives
+              </Link>
+            ) : null}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/client/src/components/backups/ExternalBackupArtifacts.tsx
+++ b/packages/client/src/components/backups/ExternalBackupArtifacts.tsx
@@ -1,0 +1,223 @@
+import { useMemo, useState } from "react";
+import { isTRPCClientError } from "@trpc/client";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table";
+import { trpc } from "@/lib/trpc";
+import { formatBytes, getBackupOperationBadgeVariant } from "@/lib/tone-utils";
+
+interface RestoreTargetPolicy {
+  id: string;
+  volumeId: string;
+  serviceName: string;
+  environmentName: string;
+  backupType: string;
+  databaseEngine: string | null;
+}
+
+export function ExternalBackupArtifacts({
+  policies,
+  enabled
+}: {
+  policies: RestoreTargetPolicy[];
+  enabled: boolean;
+}) {
+  const artifacts = trpc.externalBackupArtifacts.useQuery(
+    { limit: 50 },
+    { enabled, refetchInterval: 5_000 }
+  );
+  const verifyArtifact = trpc.triggerExternalArtifactTestRestore.useMutation();
+  const requestApproval = trpc.requestExternalArtifactRestoreApproval.useMutation();
+  const [targetByArtifact, setTargetByArtifact] = useState<Record<string, string>>({});
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const postgresTargets = useMemo(
+    () =>
+      policies.filter(
+        (policy) => policy.backupType === "database" && policy.databaseEngine === "postgres"
+      ),
+    [policies]
+  );
+
+  async function handleVerify(artifactId: string) {
+    setFeedback(null);
+    try {
+      const restore = await verifyArtifact.mutateAsync({ artifactId });
+      setFeedback(`Queued isolated verification ${restore.id}.`);
+      await artifacts.refetch();
+    } catch (error) {
+      setFeedback(
+        isTRPCClientError(error) ? error.message : "Unable to queue isolated verification."
+      );
+    }
+  }
+
+  async function handleRequestRestore(artifactId: string) {
+    const targetVolumeId = targetByArtifact[artifactId];
+    if (!targetVolumeId) return;
+    setFeedback(null);
+    try {
+      const request = await requestApproval.mutateAsync({
+        artifactId,
+        targetVolumeId,
+        reason:
+          "Restore a verified external PostgreSQL archive through the production approval gate."
+      });
+      setFeedback(`Requested production restore approval ${request.id}.`);
+    } catch (error) {
+      setFeedback(
+        isTRPCClientError(error) ? error.message : "Unable to request production restore approval."
+      );
+    }
+  }
+
+  const rows = artifacts.data?.artifacts ?? [];
+
+  if (!enabled || (!artifacts.isLoading && rows.length === 0)) return null;
+
+  return (
+    <Card data-testid="external-backup-artifacts">
+      <CardHeader>
+        <CardTitle className="text-base">External PostgreSQL archives</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Imported S3 objects stay separate from DaoFlow backup runs and cannot reach production
+          until isolated verification and approval both succeed.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {feedback ? (
+          <p
+            className="rounded-md border bg-muted px-3 py-2 text-sm"
+            data-testid="external-artifact-feedback"
+          >
+            {feedback}
+          </p>
+        ) : null}
+        {artifacts.isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading external archives…</p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Archive</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Identity</TableHead>
+                <TableHead>Target</TableHead>
+                <TableHead className="text-right">Action</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((artifact) => {
+                const targetVolumeId = targetByArtifact[artifact.id] ?? "";
+                const canVerify = artifact.status === "registered";
+                const canRequestRestore =
+                  artifact.status === "verified" && Boolean(artifact.verifiedAt);
+                return (
+                  <TableRow key={artifact.id} data-testid={`external-artifact-${artifact.id}`}>
+                    <TableCell className="max-w-[24rem]">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate font-medium" title={artifact.objectKey}>
+                          {artifact.objectKey}
+                        </span>
+                        <Badge variant="secondary">External</Badge>
+                      </div>
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {artifact.destinationName} · {formatBytes(Number(artifact.sizeBytes))} ·
+                        PostgreSQL {artifact.databaseEngineVersion ?? "pending"}
+                      </div>
+                      {artifact.error ? (
+                        <div className="mt-1 text-xs text-destructive">{artifact.error}</div>
+                      ) : null}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getBackupOperationBadgeVariant(artifact.status)}>
+                        {artifact.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="max-w-[15rem] font-mono text-xs text-muted-foreground">
+                      <div
+                        className="truncate"
+                        title={artifact.objectVersion ?? artifact.objectEtag ?? undefined}
+                      >
+                        {artifact.objectVersion ?? artifact.objectEtag}
+                      </div>
+                      <div className="truncate" title={artifact.sha256 ?? ""}>
+                        {artifact.sha256 ?? "Checksum pending"}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Select
+                        value={targetVolumeId}
+                        disabled={!canRequestRestore}
+                        onValueChange={(value) =>
+                          setTargetByArtifact((current) => ({
+                            ...current,
+                            [artifact.id]: value ?? ""
+                          }))
+                        }
+                      >
+                        <SelectTrigger
+                          className="min-w-48"
+                          aria-label={`Restore target for ${artifact.objectKey}`}
+                          data-testid={`external-artifact-target-${artifact.id}`}
+                        >
+                          <SelectValue placeholder="Select PostgreSQL target" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {postgresTargets.map((policy) => (
+                            <SelectItem key={policy.volumeId} value={policy.volumeId}>
+                              {policy.serviceName}@{policy.environmentName}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {canVerify ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={verifyArtifact.isPending}
+                          onClick={() => void handleVerify(artifact.id)}
+                          data-testid={`external-artifact-verify-${artifact.id}`}
+                        >
+                          Test restore
+                        </Button>
+                      ) : canRequestRestore ? (
+                        <Button
+                          size="sm"
+                          disabled={!targetVolumeId || requestApproval.isPending}
+                          onClick={() => void handleRequestRestore(artifact.id)}
+                          data-testid={`external-artifact-request-restore-${artifact.id}`}
+                        >
+                          Request restore
+                        </Button>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">Waiting</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/client/src/components/destinations/AddDestinationProviderFields.tsx
+++ b/packages/client/src/components/destinations/AddDestinationProviderFields.tsx
@@ -16,13 +16,14 @@ import {
   usesRemoteConfig
 } from "./add-destination-provider-config";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 
 interface AddDestinationProviderFieldsProps {
   form: AddDestinationFormState;
   copied: boolean;
   authorizeCommand?: string;
   onCopyAuthorizeCommand: () => void;
-  onFieldChange: (field: keyof AddDestinationFormState, value: string) => void;
+  onFieldChange: (field: keyof AddDestinationFormState, value: string | boolean) => void;
 }
 
 export function AddDestinationProviderFields({
@@ -115,6 +116,49 @@ export function AddDestinationProviderFields({
             value={form.endpoint}
             onChange={(event) => onFieldChange("endpoint", event.target.value)}
           />
+        </div>
+        <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <Label htmlFor="destination-external-import">Allow existing archive imports</Label>
+              <p className="text-xs text-muted-foreground">
+                Only PostgreSQL custom-format archives under the approved prefix can be registered.
+                This is disabled by default.
+              </p>
+            </div>
+            <Switch
+              id="destination-external-import"
+              data-testid="destination-external-import-enabled"
+              checked={form.externalImportEnabled}
+              onCheckedChange={(checked) =>
+                onFieldChange("externalImportEnabled", checked === true)
+              }
+            />
+          </div>
+          {form.externalImportEnabled ? (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-1.5">
+                <Label htmlFor="destination-external-import-prefix">Approved prefix</Label>
+                <Input
+                  id="destination-external-import-prefix"
+                  data-testid="destination-external-import-prefix"
+                  placeholder="database-imports/"
+                  value={form.externalImportPrefix}
+                  onChange={(event) => onFieldChange("externalImportPrefix", event.target.value)}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label htmlFor="destination-external-import-limit">Maximum bytes</Label>
+                <Input
+                  id="destination-external-import-limit"
+                  data-testid="destination-external-import-limit"
+                  inputMode="numeric"
+                  value={form.maxExternalImportBytes}
+                  onChange={(event) => onFieldChange("maxExternalImportBytes", event.target.value)}
+                />
+              </div>
+            </div>
+          ) : null}
         </div>
       </>
     );

--- a/packages/client/src/components/destinations/add-destination-payload.ts
+++ b/packages/client/src/components/destinations/add-destination-payload.ts
@@ -18,7 +18,10 @@ export function createInitialAddDestinationFormState(): AddDestinationFormState 
     s3Provider: "",
     localPath: "",
     rcloneConfig: "",
-    rcloneRemotePath: ""
+    rcloneRemotePath: "",
+    externalImportEnabled: false,
+    externalImportPrefix: "",
+    maxExternalImportBytes: String(2 * 1024 * 1024 * 1024)
   };
 }
 
@@ -45,6 +48,13 @@ export function buildDestinationPayload(form: AddDestinationFormState): Destinat
     localPath: provider === "local" ? form.localPath : undefined,
     rcloneConfig: usesRemoteConfig(provider) ? form.rcloneConfig : undefined,
     rcloneRemotePath: usesRemoteConfig(provider) ? form.rcloneRemotePath : undefined,
-    oauthToken: isOAuthProvider(provider) ? form.rcloneConfig : undefined
+    oauthToken: isOAuthProvider(provider) ? form.rcloneConfig : undefined,
+    externalImportEnabled: provider === "s3" ? form.externalImportEnabled : undefined,
+    externalImportPrefix:
+      provider === "s3" && form.externalImportEnabled ? form.externalImportPrefix : undefined,
+    maxExternalImportBytes:
+      provider === "s3" && form.externalImportEnabled
+        ? Number(form.maxExternalImportBytes)
+        : undefined
   };
 }

--- a/packages/client/src/components/destinations/add-destination-types.ts
+++ b/packages/client/src/components/destinations/add-destination-types.ts
@@ -13,6 +13,9 @@ export interface DestinationFormData {
   rcloneConfig?: string;
   rcloneRemotePath?: string;
   oauthToken?: string;
+  externalImportEnabled?: boolean;
+  externalImportPrefix?: string;
+  maxExternalImportBytes?: number;
 }
 
 export interface AddDestinationFormState {
@@ -27,4 +30,7 @@ export interface AddDestinationFormState {
   localPath: string;
   rcloneConfig: string;
   rcloneRemotePath: string;
+  externalImportEnabled: boolean;
+  externalImportPrefix: string;
+  maxExternalImportBytes: string;
 }

--- a/packages/client/src/lib/tone-utils.ts
+++ b/packages/client/src/lib/tone-utils.ts
@@ -210,7 +210,7 @@ export function getApprovalTone(status: string, riskLevel: string): StatusTone {
 }
 
 export function getBackupOperationTone(status: string): StatusTone {
-  if (status === "succeeded") {
+  if (status === "succeeded" || status === "verified") {
     return "healthy";
   }
 
@@ -218,7 +218,7 @@ export function getBackupOperationTone(status: string): StatusTone {
     return "failed";
   }
 
-  if (status === "running") {
+  if (status === "running" || status === "registering" || status === "verifying") {
     return "running";
   }
 

--- a/packages/client/src/pages/BackupsPage.test.tsx
+++ b/packages/client/src/pages/BackupsPage.test.tsx
@@ -19,6 +19,9 @@ const {
   disableBackupScheduleUseMutationMock,
   triggerBackupNowUseMutationMock,
   queueBackupRestoreUseMutationMock,
+  externalBackupArtifactsUseQueryMock,
+  triggerExternalArtifactTestRestoreUseMutationMock,
+  requestApprovalUseMutationMock,
   refetchBackupRunDetailsMock
 } = vi.hoisted(() => ({
   backupOverviewUseQueryMock: vi.fn(),
@@ -33,6 +36,9 @@ const {
   disableBackupScheduleUseMutationMock: vi.fn(),
   triggerBackupNowUseMutationMock: vi.fn(),
   queueBackupRestoreUseMutationMock: vi.fn(),
+  externalBackupArtifactsUseQueryMock: vi.fn(),
+  triggerExternalArtifactTestRestoreUseMutationMock: vi.fn(),
+  requestApprovalUseMutationMock: vi.fn(),
   refetchBackupRunDetailsMock: vi.fn()
 }));
 
@@ -83,6 +89,15 @@ vi.mock("@/lib/trpc", () => ({
     },
     queueBackupRestore: {
       useMutation: queueBackupRestoreUseMutationMock
+    },
+    externalBackupArtifacts: {
+      useQuery: externalBackupArtifactsUseQueryMock
+    },
+    triggerExternalArtifactTestRestore: {
+      useMutation: triggerExternalArtifactTestRestoreUseMutationMock
+    },
+    requestExternalArtifactRestoreApproval: {
+      useMutation: requestApprovalUseMutationMock
     },
     useUtils: () => ({
       backupOverview: { invalidate: vi.fn() },
@@ -221,6 +236,19 @@ describe("BackupsPage", () => {
         id: "restore_1"
       })
     });
+    externalBackupArtifactsUseQueryMock.mockReturnValue({
+      data: { artifacts: [] },
+      isLoading: false,
+      refetch: vi.fn()
+    });
+    triggerExternalArtifactTestRestoreUseMutationMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    });
+    requestApprovalUseMutationMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    });
   });
 
   it("opens the backup run details sheet from the runs table", () => {
@@ -295,6 +323,49 @@ describe("BackupsPage", () => {
     });
     expect(screen.getByTestId("backup-restore-feedback")).toHaveTextContent(
       "Queued restore for api."
+    );
+  });
+
+  it("queues isolated verification for a registered external archive", async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({ id: "restore_external_1", status: "queued" });
+    externalBackupArtifactsUseQueryMock.mockReturnValue({
+      data: {
+        artifacts: [
+          {
+            id: "xba_1",
+            origin: "external",
+            destinationId: "dest_primary",
+            destinationName: "approved-imports",
+            objectKey: "database-imports/customer.dump",
+            objectVersion: "v1",
+            objectEtag: '"etag-1"',
+            sizeBytes: "4096",
+            sha256: "a".repeat(64),
+            artifactFormat: "postgres-custom",
+            databaseEngineVersion: "17.4",
+            status: "registered",
+            error: null,
+            registeredAt: "2026-07-19T12:00:00.000Z",
+            updatedAt: "2026-07-19T12:00:00.000Z",
+            verifiedAt: null,
+            latestVerification: null
+          }
+        ]
+      },
+      isLoading: false,
+      refetch: vi.fn()
+    });
+    triggerExternalArtifactTestRestoreUseMutationMock.mockReturnValue({
+      isPending: false,
+      mutateAsync
+    });
+
+    renderBackupsPage();
+    fireEvent.click(screen.getByTestId("external-artifact-verify-xba_1"));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalledWith({ artifactId: "xba_1" }));
+    expect(screen.getByTestId("external-artifact-feedback")).toHaveTextContent(
+      "Queued isolated verification restore_external_1."
     );
   });
 

--- a/packages/client/src/pages/BackupsPage.tsx
+++ b/packages/client/src/pages/BackupsPage.tsx
@@ -24,6 +24,7 @@ import { useSession } from "@/lib/auth-client";
 import { queryErrorMessage } from "@/lib/query-error-message";
 import { trpc } from "@/lib/trpc";
 import { getBackupOperationBadgeVariant, formatBytes } from "@/lib/tone-utils";
+import { ExternalBackupArtifacts } from "@/components/backups/ExternalBackupArtifacts";
 
 export default function BackupsPage() {
   const session = useSession();
@@ -102,6 +103,8 @@ export default function BackupsPage() {
           {restoreFeedback}
         </p>
       ) : null}
+
+      <ExternalBackupArtifacts policies={policies} enabled={Boolean(session.data)} />
 
       {backupOverview.isLoading || backupDestinations.isLoading ? (
         <div className="space-y-4">

--- a/packages/client/src/pages/BackupsPageLoadState.test.tsx
+++ b/packages/client/src/pages/BackupsPageLoadState.test.tsx
@@ -11,6 +11,9 @@ const {
   backupOverviewUseQueryMock,
   backupRunDetailsUseQueryMock,
   queueBackupRestoreUseMutationMock,
+  externalBackupArtifactsUseQueryMock,
+  triggerExternalArtifactTestRestoreUseMutationMock,
+  requestApprovalUseMutationMock,
   refetchBackupDestinationsMock,
   refetchBackupOverviewMock
 } = vi.hoisted(() => ({
@@ -18,6 +21,9 @@ const {
   backupOverviewUseQueryMock: vi.fn(),
   backupRunDetailsUseQueryMock: vi.fn(),
   queueBackupRestoreUseMutationMock: vi.fn(),
+  externalBackupArtifactsUseQueryMock: vi.fn(),
+  triggerExternalArtifactTestRestoreUseMutationMock: vi.fn(),
+  requestApprovalUseMutationMock: vi.fn(),
   refetchBackupDestinationsMock: vi.fn(),
   refetchBackupOverviewMock: vi.fn()
 }));
@@ -45,6 +51,15 @@ vi.mock("@/lib/trpc", () => ({
     },
     queueBackupRestore: {
       useMutation: queueBackupRestoreUseMutationMock
+    },
+    externalBackupArtifacts: {
+      useQuery: externalBackupArtifactsUseQueryMock
+    },
+    triggerExternalArtifactTestRestore: {
+      useMutation: triggerExternalArtifactTestRestoreUseMutationMock
+    },
+    requestExternalArtifactRestoreApproval: {
+      useMutation: requestApprovalUseMutationMock
     }
   }
 }));
@@ -86,6 +101,19 @@ describe("BackupsPage load states", () => {
       isLoading: false
     });
     queueBackupRestoreUseMutationMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    });
+    externalBackupArtifactsUseQueryMock.mockReturnValue({
+      data: { artifacts: [] },
+      isLoading: false,
+      refetch: vi.fn()
+    });
+    triggerExternalArtifactTestRestoreUseMutationMock.mockReturnValue({
+      isPending: false,
+      mutateAsync: vi.fn()
+    });
+    requestApprovalUseMutationMock.mockReturnValue({
       isPending: false,
       mutateAsync: vi.fn()
     });

--- a/packages/client/src/pages/DestinationBrowserPage.tsx
+++ b/packages/client/src/pages/DestinationBrowserPage.tsx
@@ -15,6 +15,7 @@ import {
 import { ArrowLeft, File, Folder, HardDrive } from "lucide-react";
 import { useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { ExternalArchiveImportCard } from "@/components/backups/ExternalArchiveImportCard";
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return "—";
@@ -32,6 +33,7 @@ export default function DestinationBrowserPage() {
     { destinationId: id ?? "" },
     { enabled: Boolean(session.data) && Boolean(id) }
   );
+  const importEnabled = destination.data?.externalImportEnabled === true;
 
   const files = trpc.listDestinationFiles.useQuery(
     { id: id ?? "", path: currentPath },
@@ -75,6 +77,13 @@ export default function DestinationBrowserPage() {
           ↑ Up one level
         </Button>
       )}
+
+      <ExternalArchiveImportCard
+        destinationId={id ?? ""}
+        enabled={importEnabled}
+        approvedPrefix={destination.data?.externalImportPrefix ?? null}
+        maxBytes={Number(destination.data?.maxExternalImportBytes ?? 0)}
+      />
 
       {files.isLoading ? (
         <div className="space-y-2">

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,18 +4,18 @@
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
-  "types": "./dist/src/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
+      "types": "./src/index.ts",
       "default": "./src/index.ts"
     },
     "./router": {
-      "types": "./dist/src/router.d.ts",
+      "types": "./src/router.ts",
       "default": "./src/router.ts"
     },
     "./router-types": {
-      "types": "./dist/src/router-types.d.ts",
+      "types": "./src/router-types.ts",
       "default": "./src/router-types.ts"
     }
   },
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@1password/sdk": "0.4.0",
+    "@aws-sdk/client-s3": "3.1090.0",
     "@daoflow/shared": "workspace:*",
     "@hono/trpc-server": "0.4.2",
     "@sandbank.dev/boxlite": "0.7.1",

--- a/packages/server/src/db/schema/destinations.ts
+++ b/packages/server/src/db/schema/destinations.ts
@@ -1,4 +1,5 @@
 import {
+  boolean,
   check,
   index,
   integer,
@@ -86,6 +87,15 @@ export const backupDestinations = pgTable(
     /** Warning threshold as percentage (0-100, default 80) */
     quotaWarningPercent: integer("quota_warning_percent").default(80),
 
+    // ── External PostgreSQL import settings ──────────────────
+    // Disabled by default. These values only govern the narrowly scoped S3
+    // import path; they never turn a destination into a general object browser.
+    externalImportEnabled: boolean("external_import_enabled").default(false).notNull(),
+    externalImportPrefix: text("external_import_prefix"),
+    // Stored as text to preserve PostgreSQL bigint-range values without a JS
+    // precision loss. The constraint below bounds it to a safe operational cap.
+    maxExternalImportBytes: text("max_external_import_bytes").default("2147483648").notNull(),
+
     // ── Metadata ───────────────────────────────────────────
     organizationId: varchar("organization_id", { length: 32 }),
     lastTestedAt: timestamp("last_tested_at"),
@@ -123,6 +133,24 @@ export const backupDestinations = pgTable(
           AND ${table.rcloneConfig} IS NULL
           AND ${table.encryptionPassword} IS NULL
           AND ${table.encryptionSalt} IS NULL
+        )
+      )`
+    ),
+    check(
+      "backup_destinations_external_import_settings_check",
+      sql`(
+        ${table.maxExternalImportBytes} ~ '^[0-9]+$'
+        AND ${table.maxExternalImportBytes}::numeric BETWEEN 1048576 AND 2147483648
+        AND (
+          ${table.externalImportEnabled} = false
+          OR (
+            ${table.provider} = 's3'
+            AND ${table.encryptionMode} = 'none'
+            AND ${table.externalImportPrefix} IS NOT NULL
+            AND char_length(btrim(${table.externalImportPrefix})) > 0
+            AND ${table.externalImportPrefix} = btrim(${table.externalImportPrefix})
+            AND ${table.externalImportPrefix} !~ '(^/|//|(^|/)\\.\\.?(/|$)|\\\\)'
+          )
         )
       )`
     )

--- a/packages/server/src/db/schema/external-backup-artifacts.ts
+++ b/packages/server/src/db/schema/external-backup-artifacts.ts
@@ -1,0 +1,126 @@
+import {
+  check,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar
+} from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+import { backupDestinations } from "./destinations";
+import { teams } from "./teams";
+import { users } from "./users";
+
+export type ExternalBackupArtifactStatus =
+  "registering" | "registered" | "verifying" | "verified" | "failed";
+
+/**
+ * Imported PostgreSQL custom-format artifacts are intentionally separate from
+ * DaoFlow-created backup runs. They retain their own immutable object identity
+ * and can never cause a synthetic policy or backup run to be created.
+ */
+export const externalBackupArtifacts = pgTable(
+  "external_backup_artifacts",
+  {
+    id: varchar("id", { length: 32 }).primaryKey(),
+    teamId: varchar("team_id", { length: 32 })
+      .notNull()
+      .references(() => teams.id, { onDelete: "cascade" }),
+    destinationId: varchar("destination_id", { length: 32 })
+      .notNull()
+      .references(() => backupDestinations.id, { onDelete: "restrict" }),
+    objectKey: text("object_key").notNull(),
+    // Version IDs are not available on all S3-compatible services. An ETag is
+    // retained as the fallback immutable-read condition when it is absent.
+    objectVersion: text("object_version"),
+    objectEtag: varchar("object_etag", { length: 512 }),
+    sizeBytes: text("size_bytes").notNull(),
+    contentType: varchar("content_type", { length: 255 }),
+    lastModified: timestamp("last_modified"),
+    sha256: varchar("sha256", { length: 64 }),
+    archiveFormat: varchar("archive_format", { length: 32 }).default("postgres-custom").notNull(),
+    listingEvidence: text("listing_evidence"),
+    sourcePostgresVersion: varchar("source_postgres_version", { length: 64 }).notNull(),
+    verifierImage: text("verifier_image"),
+    status: varchar("status", { length: 20 }).default("registering").notNull(),
+    registerError: text("register_error"),
+    registeredByUserId: varchar("registered_by_user_id", { length: 32 }).references(
+      () => users.id,
+      { onDelete: "set null" }
+    ),
+    registeredAt: timestamp("registered_at"),
+    verifiedAt: timestamp("verified_at"),
+    // A compact, sanitized result from the latest isolated test restore. The
+    // full per-attempt result remains attached to backup_restores.
+    latestVerification: jsonb("latest_verification"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull()
+  },
+  (table) => [
+    index("external_backup_artifacts_team_created_idx").on(table.teamId, table.createdAt),
+    index("external_backup_artifacts_destination_created_idx").on(
+      table.destinationId,
+      table.createdAt
+    ),
+    index("external_backup_artifacts_status_idx").on(table.status),
+    uniqueIndex("external_backup_artifacts_version_identity_uq")
+      .on(table.destinationId, table.objectKey, table.objectVersion)
+      .where(sql`${table.objectVersion} IS NOT NULL`),
+    uniqueIndex("external_backup_artifacts_etag_identity_uq")
+      .on(table.destinationId, table.objectKey, table.objectEtag)
+      .where(sql`${table.objectVersion} IS NULL`),
+    check(
+      "external_backup_artifacts_identity_check",
+      sql`${table.objectVersion} IS NOT NULL OR ${table.objectEtag} IS NOT NULL`
+    ),
+    check(
+      "external_backup_artifacts_size_check",
+      sql`${table.sizeBytes} ~ '^[0-9]+$' AND ${table.sizeBytes}::numeric BETWEEN 1 AND 2147483648`
+    ),
+    check(
+      "external_backup_artifacts_archive_format_check",
+      sql`${table.archiveFormat} = 'postgres-custom'`
+    ),
+    check(
+      "external_backup_artifacts_source_version_check",
+      sql`${table.sourcePostgresVersion} ~ '^[1-9][0-9]*(\\.[0-9]+){0,2}$'`
+    ),
+    check(
+      "external_backup_artifacts_sha256_check",
+      sql`${table.sha256} IS NULL OR ${table.sha256} ~ '^[a-f0-9]{64}$'`
+    ),
+    check(
+      "external_backup_artifacts_status_check",
+      sql`${table.status} IN ('registering', 'registered', 'verifying', 'verified', 'failed')`
+    ),
+    check(
+      "external_backup_artifacts_registered_metadata_check",
+      sql`(
+        ${table.status} IN ('registering', 'failed')
+        OR (
+          ${table.sha256} IS NOT NULL
+          AND ${table.listingEvidence} IS NOT NULL
+          AND ${table.verifierImage} IS NOT NULL
+          AND ${table.registeredAt} IS NOT NULL
+        )
+      )`
+    )
+  ]
+);
+
+export const externalBackupArtifactsRelations = relations(externalBackupArtifacts, ({ one }) => ({
+  team: one(teams, {
+    fields: [externalBackupArtifacts.teamId],
+    references: [teams.id]
+  }),
+  destination: one(backupDestinations, {
+    fields: [externalBackupArtifacts.destinationId],
+    references: [backupDestinations.id]
+  }),
+  registeredBy: one(users, {
+    fields: [externalBackupArtifacts.registeredByUserId],
+    references: [users.id]
+  })
+}));

--- a/packages/server/src/db/schema/index.ts
+++ b/packages/server/src/db/schema/index.ts
@@ -7,6 +7,7 @@ export * from "./server-operations";
 export * from "./deployments";
 export * from "./storage";
 export * from "./destinations";
+export * from "./external-backup-artifacts";
 export * from "./audit";
 export * from "./request-access-logs";
 export * from "./account-security";

--- a/packages/server/src/db/schema/storage.ts
+++ b/packages/server/src/db/schema/storage.ts
@@ -12,6 +12,7 @@ import { relations, sql } from "drizzle-orm";
 import { servers } from "./servers";
 import { users } from "./users";
 import { backupDestinations } from "./destinations";
+import { externalBackupArtifacts } from "./external-backup-artifacts";
 
 export interface BackupRunLogEntry {
   timestamp: string;
@@ -154,9 +155,14 @@ export const backupRestores = pgTable(
   "backup_restores",
   {
     id: varchar("id", { length: 32 }).primaryKey(),
-    backupRunId: varchar("backup_run_id", { length: 32 })
-      .notNull()
-      .references(() => backupRuns.id),
+    backupRunId: varchar("backup_run_id", { length: 32 }).references(() => backupRuns.id),
+    externalArtifactId: varchar("external_artifact_id", { length: 32 }).references(
+      () => externalBackupArtifacts.id,
+      { onDelete: "restrict" }
+    ),
+    targetVolumeId: varchar("target_volume_id", { length: 32 }).references(() => volumes.id, {
+      onDelete: "restrict"
+    }),
     mode: varchar("mode", { length: 20 }).default("restore").notNull(),
     status: varchar("status", { length: 20 }).default("queued").notNull(),
     targetPath: text("target_path"),
@@ -171,11 +177,33 @@ export const backupRestores = pgTable(
   },
   (table) => [
     index("backup_restores_backup_run_id_idx").on(table.backupRunId),
+    index("backup_restores_external_artifact_id_idx").on(table.externalArtifactId),
+    index("backup_restores_target_volume_id_idx").on(table.targetVolumeId),
     index("backup_restores_created_at_idx").on(table.createdAt),
     check("backup_restores_mode_check", sql`${table.mode} IN ('restore', 'verification')`),
     check(
       "backup_restores_verification_result_mode_check",
       sql`${table.verificationResult} IS NULL OR ${table.mode} = 'verification'`
+    ),
+    check(
+      "backup_restores_source_xor_check",
+      sql`(
+        (${table.backupRunId} IS NOT NULL AND ${table.externalArtifactId} IS NULL)
+        OR (${table.backupRunId} IS NULL AND ${table.externalArtifactId} IS NOT NULL)
+      )`
+    ),
+    check(
+      "backup_restores_external_target_mode_check",
+      sql`(
+        (${table.backupRunId} IS NOT NULL AND ${table.targetVolumeId} IS NULL)
+        OR (
+          ${table.externalArtifactId} IS NOT NULL
+          AND (
+            (${table.mode} = 'verification' AND ${table.targetVolumeId} IS NULL)
+            OR (${table.mode} = 'restore' AND ${table.targetVolumeId} IS NOT NULL)
+          )
+        )
+      )`
     )
   ]
 );
@@ -216,6 +244,14 @@ export const backupRestoresRelations = relations(backupRestores, ({ one }) => ({
   backupRun: one(backupRuns, {
     fields: [backupRestores.backupRunId],
     references: [backupRuns.id]
+  }),
+  externalArtifact: one(externalBackupArtifacts, {
+    fields: [backupRestores.externalArtifactId],
+    references: [externalBackupArtifacts.id]
+  }),
+  targetVolume: one(volumes, {
+    fields: [backupRestores.targetVolumeId],
+    references: [volumes.id]
   }),
   triggeredByUser: one(users, {
     fields: [backupRestores.triggeredByUserId],

--- a/packages/server/src/db/services/approval-dispatch-reconciliation.ts
+++ b/packages/server/src/db/services/approval-dispatch-reconciliation.ts
@@ -27,7 +27,10 @@ async function getOperationTerminalState(
   tx: ApprovalDispatchTransaction,
   dispatch: ApprovalDispatchRow
 ) {
-  if (dispatch.actionType === "backup-restore") {
+  if (
+    dispatch.actionType === "backup-restore" ||
+    dispatch.actionType === "external-artifact-restore"
+  ) {
     const [restore] = await tx
       .select({ status: backupRestores.status, error: backupRestores.error })
       .from(backupRestores)

--- a/packages/server/src/db/services/approval-dispatch-service.test.ts
+++ b/packages/server/src/db/services/approval-dispatch-service.test.ts
@@ -4,6 +4,7 @@ import { db } from "../connection";
 import { approvalActionDispatches, approvalRequests, auditEntries } from "../schema/audit";
 import { deployments } from "../schema/deployments";
 import { environments, projects } from "../schema/projects";
+import { backupRestores } from "../schema/storage";
 import { teamMembers, teams } from "../schema/teams";
 import { users } from "../schema/users";
 import { resetTestDatabaseWithControlPlane } from "../../test-db";
@@ -308,6 +309,47 @@ describe("approval action dispatch service", () => {
       status: "succeeded",
       operationId: completedDeployment.id
     });
+  });
+
+  it("reconciles external artifact restores through the restore operation table", async () => {
+    const now = new Date();
+    const requestId = "apr_external_reconcile";
+    const dispatchId = "adsp_external_reconcile";
+    const operationId = "brestore_vol_verify";
+    await db
+      .update(backupRestores)
+      .set({ status: "succeeded", error: null, completedAt: now })
+      .where(eq(backupRestores.id, operationId));
+    await db.insert(approvalRequests).values({
+      id: requestId,
+      teamId: "team_foundation",
+      actionType: "external-artifact-restore",
+      targetResource: "external-backup-artifact/xart_reconcile",
+      status: "approved",
+      inputSummary: {},
+      createdAt: now
+    });
+    await db.insert(approvalActionDispatches).values({
+      id: dispatchId,
+      approvalRequestId: requestId,
+      teamId: "team_foundation",
+      actionType: "external-artifact-restore",
+      idempotencyKey: `approval:${requestId}`,
+      operationId,
+      payloadVersion: 1,
+      payloadHash: "b".repeat(64),
+      actionPayload: {},
+      status: "dispatched",
+      attemptCount: 1,
+      nextAttemptAt: now,
+      dispatchedAt: now,
+      createdAt: now,
+      updatedAt: now
+    });
+
+    await expect(reconcileApprovalActionDispatches({ now })).resolves.toEqual([
+      expect.objectContaining({ id: dispatchId, operationId, status: "succeeded" })
+    ]);
   });
 
   it("reuses a preallocated deployment operation ID without creating duplicate records", async () => {

--- a/packages/server/src/db/services/approval-dispatch-service.ts
+++ b/packages/server/src/db/services/approval-dispatch-service.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../connection";
 import { approvalActionDispatches, approvalRequests } from "../schema/audit";
 import { queueBackupRestore } from "./backup-restores";
+import { queueExternalArtifactRestore } from "./external-backup-artifacts";
 import {
   claimNextApprovalActionDispatch,
   getApprovalDispatchRetryConfig,
@@ -156,6 +157,25 @@ export async function executeApprovalActionDispatch(
     if (!restore) {
       throw new TerminalApprovalDispatchError(
         "The approved backup restore target no longer belongs to this team or is no longer restorable."
+      );
+    }
+    return;
+  }
+  if (payload.actionType === "external-artifact-restore") {
+    const restore = await queueExternalArtifactRestore({
+      artifactId: payload.artifactId,
+      targetVolumeId: payload.targetVolumeId,
+      teamId: dispatch.teamId,
+      actor: payload.actor,
+      approvalRequestId: dispatch.approvalRequestId,
+      operationId: dispatch.operationId,
+      approvalDispatchId: dispatch.id,
+      preserveDispatchRetry: true,
+      approvalSnapshot: payload.snapshot
+    });
+    if (!restore) {
+      throw new TerminalApprovalDispatchError(
+        "The approved external artifact restore target is no longer verified or available to this team."
       );
     }
     return;

--- a/packages/server/src/db/services/approval-dispatch-types.ts
+++ b/packages/server/src/db/services/approval-dispatch-types.ts
@@ -42,6 +42,15 @@ export type ApprovalActionPayload =
     }
   | {
       version: 1;
+      actionType: "external-artifact-restore";
+      targetResource: string;
+      actor: DispatchActor;
+      artifactId: string;
+      targetVolumeId: string;
+      snapshot: Record<string, unknown>;
+    }
+  | {
+      version: 1;
       actionType: "preview-deployment";
       targetResource: string;
       actor: DispatchActor;
@@ -79,6 +88,13 @@ function stableJson(value: unknown): string {
 
 function hasSnapshotStrings(snapshot: Record<string, unknown>, keys: readonly string[]) {
   return keys.every((key) => Boolean(readString(snapshot, key)));
+}
+
+function hasExternalArtifactIdentity(snapshot: Record<string, unknown>) {
+  return (
+    Boolean(readString(snapshot, "artifactObjectVersion")) ||
+    Boolean(readString(snapshot, "artifactObjectEtag"))
+  );
 }
 
 export function hashApprovalActionPayload(payload: ApprovalActionPayload): string {
@@ -162,6 +178,50 @@ export function buildApprovalActionPayload(input: {
         };
   }
 
+  if (input.request.actionType === "external-artifact-restore") {
+    const artifactId = readString(action, "artifactId");
+    const targetVolumeId = readString(action, "targetVolumeId");
+    return artifactId &&
+      targetVolumeId &&
+      hasSnapshotStrings(snapshot, [
+        "artifactId",
+        "artifactSha256",
+        "artifactObjectKey",
+        "artifactVerifiedAt",
+        "destinationId",
+        "destinationUpdatedAt",
+        "targetVolumeId",
+        "targetVolumeUpdatedAt",
+        "targetServerId",
+        "targetMountPath",
+        "targetServiceId",
+        "targetServiceUpdatedAt",
+        "runtimeServiceName",
+        "databaseEngine",
+        "databaseName",
+        "databaseUser",
+        "secretPolicy"
+      ]) &&
+      hasExternalArtifactIdentity(snapshot)
+      ? {
+          version: 1,
+          actionType: "external-artifact-restore",
+          targetResource: input.request.targetResource,
+          actor: input.actor,
+          artifactId,
+          targetVolumeId,
+          snapshot
+        }
+      : {
+          version: 1,
+          actionType: "invalid",
+          targetResource: input.request.targetResource,
+          actor: input.actor,
+          reason: "The approved external artifact restore binding is incomplete.",
+          snapshot
+        };
+  }
+
   if (input.request.actionType === "preview-deployment") {
     const binding = readPreviewApprovalBinding(summary.previewTrust);
     return binding &&
@@ -235,6 +295,14 @@ export function readApprovalActionPayload(value: unknown): ApprovalActionPayload
     const backupRunId = readString(payload, "backupRunId");
     return backupRunId
       ? { version: 1, actionType, targetResource, actor, backupRunId, snapshot }
+      : null;
+  }
+
+  if (actionType === "external-artifact-restore") {
+    const artifactId = readString(payload, "artifactId");
+    const targetVolumeId = readString(payload, "targetVolumeId");
+    return artifactId && targetVolumeId
+      ? { version: 1, actionType, targetResource, actor, artifactId, targetVolumeId, snapshot }
       : null;
   }
 

--- a/packages/server/src/db/services/approvals.ts
+++ b/packages/server/src/db/services/approvals.ts
@@ -19,8 +19,13 @@ import {
 import { resolveVolumeTeamId } from "./backup-resource-team";
 import { createApprovalActionDispatchIntent } from "./approval-dispatch-service";
 import { buildApprovalActionPayload, toApprovalDispatchView } from "./approval-dispatch-types";
+import {
+  buildExternalRestoreApprovalSnapshot,
+  resolveExternalArtifactRestoreTarget
+} from "./external-backup-artifacts";
 
-export type ApprovalActionType = "compose-release" | "backup-restore" | "preview-deployment";
+export type ApprovalActionType =
+  "compose-release" | "backup-restore" | "external-artifact-restore" | "preview-deployment";
 
 type ApprovalRequester = {
   teamId: string;
@@ -40,6 +45,12 @@ export type CreateApprovalRequestInput =
   | ({
       actionType: "backup-restore";
       backupRunId: string;
+      reason: string;
+    } & ApprovalRequester)
+  | ({
+      actionType: "external-artifact-restore";
+      artifactId: string;
+      targetVolumeId: string;
       reason: string;
     } & ApprovalRequester)
   | ({
@@ -164,6 +175,33 @@ async function resolveApprovalPresentation(input: CreateApprovalRequestInput) {
           allowedSecretProfile: input.previewTrust.allowedSecretProfile,
           bindingPolicyRevision: input.previewTrust.policyRevision
         }
+      }
+    } as const;
+  }
+
+  if (input.actionType === "external-artifact-restore") {
+    const target = await resolveExternalArtifactRestoreTarget({
+      artifactId: input.artifactId,
+      targetVolumeId: input.targetVolumeId,
+      teamId: input.teamId
+    });
+    if (!target || target.artifact.status !== "verified" || !target.artifact.sha256) return null;
+    const snapshot = buildExternalRestoreApprovalSnapshot(target);
+    return {
+      teamId: input.teamId,
+      targetResource: `external-backup-artifact/${target.artifact.id}`,
+      resourceLabel: `${target.destination.name}:${target.artifact.objectKey}`,
+      riskLevel: "critical",
+      commandSummary: `Restore verified external PostgreSQL artifact to ${target.runtimeServiceName}.`,
+      recommendedChecks: [
+        "Confirm the artifact checksum and isolated verification remain current.",
+        "Confirm the selected PostgreSQL target is isolated from conflicting writes."
+      ],
+      expiresAt: new Date(Date.now() + 7 * 60 * 60 * 1000).toISOString(),
+      actionPayload: {
+        artifactId: target.artifact.id,
+        targetVolumeId: target.volume.id,
+        snapshot
       }
     } as const;
   }
@@ -310,7 +348,10 @@ export async function createApprovalRequest(input: CreateApprovalRequestInput) {
     targetResource: `approval-request/${requestId}`,
     action: "approval.request",
     inputSummary: `Approval requested for ${presentation.resourceLabel}.`,
-    permissionScope: "deploy:start",
+    permissionScope:
+      input.actionType === "backup-restore" || input.actionType === "external-artifact-restore"
+        ? "backup:restore"
+        : "deploy:start",
     outcome: "success",
     metadata: {
       teamId: presentation.teamId,

--- a/packages/server/src/db/services/backup-team-lists.ts
+++ b/packages/server/src/db/services/backup-team-lists.ts
@@ -193,7 +193,7 @@ export async function listBackupRestoreQueueForTeam(teamId: string, limit = 12) 
       failedRequests: restores.filter((restore) => restore.status === "failed").length
     },
     requests: restores.map((restore) => {
-      const run = runsById.get(restore.backupRunId);
+      const run = restore.backupRunId ? runsById.get(restore.backupRunId) : undefined;
       const policy = run ? relations.policiesById.get(run.policyId) : undefined;
       const volume = policy ? relations.volumesById.get(policy.volumeId) : undefined;
       const server = volume ? relations.serversById.get(volume.serverId) : undefined;

--- a/packages/server/src/db/services/backups.ts
+++ b/packages/server/src/db/services/backups.ts
@@ -199,7 +199,13 @@ export async function listBackupRestoreQueue(limit = 12) {
     .orderBy(desc(backupRestores.createdAt))
     .limit(limit);
 
-  const backupRunIds = [...new Set(restores.map((restore) => restore.backupRunId))];
+  const backupRunIds = [
+    ...new Set(
+      restores
+        .map((restore) => restore.backupRunId)
+        .filter((runId): runId is string => typeof runId === "string")
+    )
+  ];
   const runRows =
     backupRunIds.length > 0
       ? await db.select().from(backupRuns).where(inArray(backupRuns.id, backupRunIds))
@@ -227,7 +233,7 @@ export async function listBackupRestoreQueue(limit = 12) {
       failedRequests: restores.filter((restore) => restore.status === "failed").length
     },
     requests: restores.map((restore) => {
-      const run = runsById.get(restore.backupRunId);
+      const run = restore.backupRunId ? runsById.get(restore.backupRunId) : undefined;
       const policy = run ? relations.policiesById.get(run.policyId) : undefined;
       const volume = policy ? relations.volumesById.get(policy.volumeId) : undefined;
       const server = volume ? relations.serversById.get(volume.serverId) : undefined;

--- a/packages/server/src/db/services/destination-shared.ts
+++ b/packages/server/src/db/services/destination-shared.ts
@@ -31,6 +31,9 @@ export interface CreateDestinationInput {
   encryptionSalt?: string | null;
   filenameEncryption?: string;
   localPath?: string;
+  externalImportEnabled?: boolean;
+  externalImportPrefix?: string | null;
+  maxExternalImportBytes?: number | string | null;
 }
 
 export interface UpdateDestinationInput extends Partial<CreateDestinationInput> {
@@ -131,6 +134,9 @@ export function toPublicDestinationView(row: DestinationRow) {
     encryptionMode: row.encryptionMode,
     filenameEncryption: row.filenameEncryption,
     localPath: row.localPath,
+    externalImportEnabled: row.externalImportEnabled,
+    externalImportPrefix: row.externalImportPrefix,
+    maxExternalImportBytes: Number(row.maxExternalImportBytes),
     lastTestedAt: row.lastTestedAt?.toISOString() ?? null,
     lastTestResult: row.lastTestResult,
     createdAt: row.createdAt.toISOString(),

--- a/packages/server/src/db/services/destinations.ts
+++ b/packages/server/src/db/services/destinations.ts
@@ -3,6 +3,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { db } from "../connection";
 import { auditEntries } from "../schema/audit";
 import { backupDestinations } from "../schema/destinations";
+import { externalBackupArtifacts } from "../schema/external-backup-artifacts";
 import { backupPolicies } from "../schema/storage";
 import { testConnection } from "../../worker/rclone-executor";
 import { newId as id } from "./json-helpers";
@@ -17,6 +18,7 @@ import {
   encryptDestinationCredentials,
   redactDestinationCredentialValues
 } from "./destination-credentials";
+import { normalizeExternalImportSettings } from "./external-import-settings";
 
 export type { CreateDestinationInput, UpdateDestinationInput } from "./destination-shared";
 
@@ -61,6 +63,7 @@ export async function createDestination(
   const destId = id();
   const now = new Date();
   const encryptedCredentials = encryptDestinationCredentials(input);
+  const externalImportSettings = normalizeExternalImportSettings(input);
   const [row] = await db
     .insert(backupDestinations)
     .values({
@@ -86,6 +89,7 @@ export async function createDestination(
       encryptionSalt: null,
       filenameEncryption: input.filenameEncryption,
       localPath: input.localPath ?? null,
+      ...externalImportSettings,
       createdAt: now,
       updatedAt: now
     })
@@ -121,6 +125,7 @@ export async function updateDestination(
     const encryptedCredentials = encryptDestinationCredentials(
       mergeDestinationCredentials(existing, input)
     );
+    const externalImportSettings = normalizeExternalImportSettings(input, existing);
     const updateData: Record<string, unknown> = { updatedAt: new Date() };
     for (const key of [
       "name",
@@ -133,11 +138,15 @@ export async function updateDestination(
       "rcloneRemotePath",
       "encryptionMode",
       "filenameEncryption",
-      "localPath"
+      "localPath",
+      "externalImportEnabled",
+      "externalImportPrefix",
+      "maxExternalImportBytes"
     ] as const) {
       if (input[key] !== undefined) updateData[key] = input[key];
     }
     Object.assign(updateData, encryptedCredentials, {
+      ...externalImportSettings,
       accessKey: null,
       secretAccessKey: null,
       oauthToken: null,
@@ -194,6 +203,18 @@ export async function deleteDestination(
     return {
       deleted: false,
       error: "Cannot delete: destination is used by one or more backup policies."
+    };
+  }
+
+  const [linkedArtifact] = await db
+    .select({ id: externalBackupArtifacts.id })
+    .from(externalBackupArtifacts)
+    .where(eq(externalBackupArtifacts.destinationId, destinationId))
+    .limit(1);
+  if (linkedArtifact) {
+    return {
+      deleted: false,
+      error: "Cannot delete: destination has registered external backup artifacts."
     };
   }
 

--- a/packages/server/src/db/services/external-backup-artifact-audit.ts
+++ b/packages/server/src/db/services/external-backup-artifact-audit.ts
@@ -1,0 +1,38 @@
+import type { AppRole } from "@daoflow/shared";
+import { db } from "../connection";
+import { auditEntries } from "../schema/audit";
+
+export async function writeExternalBackupArtifactAudit(input: {
+  actor?: { userId: string; email: string; role: AppRole };
+  teamId: string;
+  destinationId: string;
+  artifactId?: string;
+  objectKey?: string;
+  action: string;
+  permissionScope: string;
+  outcome: "success" | "failure" | "denied";
+  detail: string;
+}) {
+  await db.insert(auditEntries).values({
+    actorType: input.actor ? "user" : "system",
+    actorId: input.actor?.userId ?? "external-artifact-worker",
+    actorEmail: input.actor?.email ?? "system@daoflow.local",
+    actorRole: input.actor?.role ?? "system",
+    organizationId: input.teamId,
+    targetResource: input.artifactId
+      ? `external-backup-artifact/${input.artifactId}`
+      : `backup-destination/${input.destinationId}`,
+    action: input.action,
+    inputSummary: input.detail,
+    permissionScope: input.permissionScope,
+    outcome: input.outcome,
+    metadata: {
+      teamId: input.teamId,
+      resourceType: "external-backup-artifact",
+      ...(input.artifactId ? { resourceId: input.artifactId } : {}),
+      destinationId: input.destinationId,
+      ...(input.objectKey ? { objectKey: input.objectKey } : {}),
+      detail: input.detail
+    }
+  });
+}

--- a/packages/server/src/db/services/external-backup-artifact-read-runtime.test.ts
+++ b/packages/server/src/db/services/external-backup-artifact-read-runtime.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveExecutionTarget: vi.fn(),
+  resolveServiceRuntime: vi.fn(),
+  select: vi.fn()
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...values: unknown[]) => values),
+  desc: vi.fn((value: unknown) => value),
+  eq: vi.fn((...values: unknown[]) => values)
+}));
+vi.mock("../connection", () => ({ db: { select: mocks.select } }));
+vi.mock("../schema/destinations", () => ({ backupDestinations: {} }));
+vi.mock("../schema/external-backup-artifacts", () => ({ externalBackupArtifacts: {} }));
+vi.mock("../schema/projects", () => ({ projects: { id: {}, teamId: {} } }));
+vi.mock("../schema/servers", () => ({ servers: { id: {}, teamId: {} } }));
+vi.mock("../schema/services", () => ({ services: { id: {}, projectId: {} } }));
+vi.mock("../schema/storage", () => ({ volumes: {} }));
+vi.mock("../../worker/execution-target", () => ({
+  resolveExecutionTarget: mocks.resolveExecutionTarget
+}));
+vi.mock("./backup-resource-team", () => ({ resolveVolumeTeamId: vi.fn() }));
+vi.mock("./service-runtime", () => ({ resolveServiceRuntime: mocks.resolveServiceRuntime }));
+
+import { resolveExternalPostgresRestoreRuntime } from "./external-backup-artifact-read";
+
+const updatedAt = new Date("2026-07-19T00:00:00.000Z");
+const volume = {
+  id: "vol_postgres",
+  serverId: "srv_approved",
+  metadata: { serviceId: "svc_postgres" }
+};
+const service = {
+  id: "svc_postgres",
+  targetServerId: "srv_approved",
+  updatedAt,
+  config: {
+    managedDatabase: {
+      kind: "postgres",
+      label: "PostgreSQL",
+      templateSlug: "postgres",
+      databaseName: "app",
+      username: "app_user",
+      port: "5432",
+      internalPort: "5432",
+      serviceName: "postgres",
+      volumeName: "postgres-data",
+      volumeId: "vol_postgres",
+      backupEngine: "postgres",
+      connectionUriMasked: "postgres://app_user:[redacted]@db/app",
+      internalConnectionUriMasked: "postgres://app_user:[redacted]@db/app"
+    }
+  }
+};
+
+function selectRows(rows: unknown[]) {
+  return {
+    from: () => ({ innerJoin: () => ({ where: () => ({ limit: () => Promise.resolve(rows) }) }) })
+  };
+}
+
+describe("external PostgreSQL restore runtime resolution", () => {
+  beforeEach(() => {
+    mocks.resolveExecutionTarget.mockReset();
+    mocks.resolveServiceRuntime.mockReset();
+    mocks.select.mockReset();
+    mocks.select.mockImplementation(() =>
+      selectRows([{ service, projectTeamId: "team_foundation" }])
+    );
+  });
+
+  it.each([
+    { mode: "local" as const },
+    {
+      mode: "remote" as const,
+      remoteWorkDir: "/tmp/restore",
+      ssh: { serverName: "production", host: "203.0.113.8", port: 22 }
+    }
+  ])("keeps the approved $mode server and its Compose runtime together", async (target) => {
+    mocks.resolveServiceRuntime.mockResolvedValue({
+      status: "ok",
+      runtime: {
+        kind: "compose",
+        service: { id: "svc_postgres" },
+        server: { id: "srv_approved" },
+        target,
+        projectName: "app-production",
+        composeServiceName: "postgres"
+      }
+    });
+
+    await expect(
+      resolveExternalPostgresRestoreRuntime({
+        volume: volume as never,
+        teamId: "team_foundation",
+        restoreId: "brest_postgres"
+      })
+    ).resolves.toMatchObject({
+      target,
+      runtime: {
+        kind: "compose",
+        projectName: "app-production",
+        serviceName: "postgres"
+      }
+    });
+  });
+
+  it("fails closed when the live service runtime moves away from the approved volume server", async () => {
+    mocks.resolveServiceRuntime.mockResolvedValue({
+      status: "ok",
+      runtime: {
+        kind: "compose",
+        service: { id: "svc_postgres" },
+        server: { id: "srv_other" },
+        target: { mode: "local" },
+        projectName: "app-production",
+        composeServiceName: "postgres"
+      }
+    });
+
+    await expect(
+      resolveExternalPostgresRestoreRuntime({
+        volume: volume as never,
+        teamId: "team_foundation",
+        restoreId: "brest_postgres"
+      })
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/server/src/db/services/external-backup-artifact-read.ts
+++ b/packages/server/src/db/services/external-backup-artifact-read.ts
@@ -1,0 +1,188 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "../connection";
+import { backupDestinations } from "../schema/destinations";
+import { externalBackupArtifacts } from "../schema/external-backup-artifacts";
+import { projects } from "../schema/projects";
+import { servers } from "../schema/servers";
+import { services } from "../schema/services";
+import { volumes } from "../schema/storage";
+import { readManagedDatabaseConfigFromConfig } from "../../managed-database-config";
+import { resolveExecutionTarget, type ExecutionTarget } from "../../worker/execution-target";
+import { resolveVolumeTeamId } from "./backup-resource-team";
+import { asRecord, readString } from "./json-helpers";
+import { resolveServiceRuntime } from "./service-runtime";
+import {
+  resolveExternalArtifact,
+  toExternalBackupArtifactView
+} from "./external-backup-artifact-shared";
+
+export async function listExternalBackupArtifacts(input: {
+  teamId: string;
+  destinationId?: string;
+  limit?: number;
+}) {
+  const rows = await db
+    .select({ artifact: externalBackupArtifacts, destinationName: backupDestinations.name })
+    .from(externalBackupArtifacts)
+    .innerJoin(backupDestinations, eq(backupDestinations.id, externalBackupArtifacts.destinationId))
+    .where(
+      input.destinationId
+        ? and(
+            eq(externalBackupArtifacts.teamId, input.teamId),
+            eq(externalBackupArtifacts.destinationId, input.destinationId)
+          )
+        : eq(externalBackupArtifacts.teamId, input.teamId)
+    )
+    .orderBy(desc(externalBackupArtifacts.createdAt))
+    .limit(input.limit ?? 50);
+  return {
+    artifacts: rows.map((row) => toExternalBackupArtifactView(row.artifact, row.destinationName))
+  };
+}
+
+export async function getExternalBackupArtifact(artifactId: string, teamId: string) {
+  const [row] = await db
+    .select({ artifact: externalBackupArtifacts, destinationName: backupDestinations.name })
+    .from(externalBackupArtifacts)
+    .innerJoin(backupDestinations, eq(backupDestinations.id, externalBackupArtifacts.destinationId))
+    .where(
+      and(eq(externalBackupArtifacts.id, artifactId), eq(externalBackupArtifacts.teamId, teamId))
+    )
+    .limit(1);
+  return row ? toExternalBackupArtifactView(row.artifact, row.destinationName) : null;
+}
+
+export type ExternalPostgresTargetMetadata = {
+  databaseName: string;
+  databaseUser: string;
+  runtimeServiceName: string;
+  targetServiceId: string;
+  targetServiceUpdatedAt: string;
+  runtimeBinding:
+    { kind: "service"; serviceId: string } | { kind: "container"; containerName: string };
+};
+
+export type ExternalPostgresRestoreRuntime = ExternalPostgresTargetMetadata & {
+  target: ExecutionTarget;
+  runtime:
+    | { kind: "container"; containerName: string }
+    | { kind: "compose"; projectName: string; serviceName: string };
+};
+
+export async function resolveExternalPostgresTargetMetadata(
+  volume: typeof volumes.$inferSelect,
+  teamId: string
+): Promise<ExternalPostgresTargetMetadata | null> {
+  const metadata = asRecord(volume.metadata);
+  const serviceId = readString(metadata, "serviceId");
+  if (serviceId) {
+    const [row] = await db
+      .select({ service: services, projectTeamId: projects.teamId })
+      .from(services)
+      .innerJoin(projects, eq(projects.id, services.projectId))
+      .where(eq(services.id, serviceId))
+      .limit(1);
+    const managed = row ? readManagedDatabaseConfigFromConfig(row.service.config) : null;
+    if (
+      !row ||
+      row.projectTeamId !== teamId ||
+      (row.service.targetServerId && row.service.targetServerId !== volume.serverId) ||
+      managed?.kind !== "postgres" ||
+      managed.backupEngine !== "postgres" ||
+      managed.volumeId !== volume.id ||
+      !managed.databaseName ||
+      !managed.username ||
+      !managed.serviceName
+    ) {
+      return null;
+    }
+    return {
+      databaseName: managed.databaseName,
+      databaseUser: managed.username,
+      runtimeServiceName: managed.serviceName,
+      targetServiceId: row.service.id,
+      targetServiceUpdatedAt: row.service.updatedAt.toISOString(),
+      runtimeBinding: { kind: "service", serviceId: row.service.id }
+    };
+  }
+
+  const databaseEngine = readString(metadata, "databaseEngine");
+  const databaseName = readString(metadata, "databaseName");
+  const databaseUser = readString(metadata, "databaseUser");
+  const containerName = readString(metadata, "containerName");
+  if (databaseEngine !== "postgres" || !databaseName || !databaseUser || !containerName)
+    return null;
+  return {
+    databaseName,
+    databaseUser,
+    runtimeServiceName: containerName,
+    targetServiceId: `manual-volume:${volume.id}`,
+    targetServiceUpdatedAt: volume.updatedAt.toISOString(),
+    runtimeBinding: { kind: "container", containerName }
+  };
+}
+
+export async function resolveExternalPostgresRestoreRuntime(input: {
+  volume: typeof volumes.$inferSelect;
+  teamId: string;
+  restoreId: string;
+}): Promise<ExternalPostgresRestoreRuntime | null> {
+  const metadata = await resolveExternalPostgresTargetMetadata(input.volume, input.teamId);
+  if (!metadata) return null;
+
+  if (metadata.runtimeBinding.kind === "container") {
+    const [server] = await db
+      .select()
+      .from(servers)
+      .where(and(eq(servers.id, input.volume.serverId), eq(servers.teamId, input.teamId)))
+      .limit(1);
+    if (!server) return null;
+    return {
+      ...metadata,
+      target: await resolveExecutionTarget(
+        server,
+        `external_restore_${input.restoreId}`,
+        input.teamId
+      ),
+      runtime: { kind: "container", containerName: metadata.runtimeBinding.containerName }
+    };
+  }
+
+  const resolved = await resolveServiceRuntime(metadata.runtimeBinding.serviceId, {
+    teamId: input.teamId
+  });
+  if (
+    resolved.status !== "ok" ||
+    resolved.runtime.service.id !== metadata.targetServiceId ||
+    resolved.runtime.server.id !== input.volume.serverId
+  ) {
+    return null;
+  }
+  return {
+    ...metadata,
+    target: resolved.runtime.target,
+    runtime:
+      resolved.runtime.kind === "compose"
+        ? {
+            kind: "compose",
+            projectName: resolved.runtime.projectName,
+            serviceName: resolved.runtime.composeServiceName
+          }
+        : { kind: "container", containerName: resolved.runtime.containerName }
+  };
+}
+
+export async function resolveExternalArtifactRestoreTarget(input: {
+  artifactId: string;
+  targetVolumeId: string;
+  teamId: string;
+}) {
+  const [resolved, volumeRows] = await Promise.all([
+    resolveExternalArtifact(input.artifactId, input.teamId),
+    db.select().from(volumes).where(eq(volumes.id, input.targetVolumeId)).limit(1)
+  ]);
+  const volume = volumeRows[0];
+  if (!resolved || !volume || (await resolveVolumeTeamId(volume)) !== input.teamId) return null;
+  const postgres = await resolveExternalPostgresTargetMetadata(volume, input.teamId);
+  return postgres ? { ...resolved, volume, ...postgres } : null;
+}

--- a/packages/server/src/db/services/external-backup-artifact-registration.ts
+++ b/packages/server/src/db/services/external-backup-artifact-registration.ts
@@ -1,0 +1,294 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "../connection";
+import { externalBackupArtifacts } from "../schema/external-backup-artifacts";
+import { backupRestores } from "../schema/storage";
+import {
+  buildExternalArtifactImportWorkflowId,
+  startExternalArtifactImportWorkflow,
+  startExternalArtifactVerificationWorkflow
+} from "../../worker";
+import { isTemporalEnabled } from "../../worker/temporal/temporal-config";
+import { createExternalS3Adapter } from "../../worker/external-backup-s3";
+import { writeExternalBackupArtifactAudit } from "./external-backup-artifact-audit";
+import {
+  asExternalArtifactError,
+  assertPostgresMajor,
+  requireExternalDestination,
+  resolveExternalArtifact,
+  toExternalBackupArtifactView,
+  toExternalS3Destination,
+  type ExternalArtifactActor
+} from "./external-backup-artifact-shared";
+import { newId as id } from "./json-helpers";
+
+export async function listExternalBackupObjects(input: {
+  destinationId: string;
+  prefix?: string;
+  teamId: string;
+  actor: ExternalArtifactActor;
+}) {
+  const destination = await requireExternalDestination(input.destinationId, input.teamId);
+  try {
+    const result = await createExternalS3Adapter(toExternalS3Destination(destination)).listObjects(
+      input.prefix
+    );
+    await writeExternalBackupArtifactAudit({
+      actor: input.actor,
+      teamId: input.teamId,
+      destinationId: destination.id,
+      action: "external-artifact.list",
+      permissionScope: "backup:read",
+      outcome: "success",
+      detail: "Listed external backup objects under the approved import prefix."
+    });
+    return {
+      destination: {
+        id: destination.id,
+        name: destination.name,
+        provider: destination.provider,
+        externalImportEnabled: destination.externalImportEnabled,
+        externalImportPrefix: destination.externalImportPrefix,
+        maxExternalImportBytes: Number(destination.maxExternalImportBytes)
+      },
+      prefix: result.prefix,
+      objects: result.objects
+    };
+  } catch (error) {
+    await writeExternalBackupArtifactAudit({
+      actor: input.actor,
+      teamId: input.teamId,
+      destinationId: input.destinationId,
+      action: "external-artifact.list.denied",
+      permissionScope: "backup:read",
+      outcome: "denied",
+      detail: "External backup object listing was denied."
+    });
+    throw asExternalArtifactError(error);
+  }
+}
+
+export async function registerExternalBackupArtifact(input: {
+  destinationId: string;
+  objectKey: string;
+  postgresMajor: string;
+  teamId: string;
+  actor: ExternalArtifactActor;
+}) {
+  if (!isTemporalEnabled()) {
+    throw asExternalArtifactError(new Error("External backup imports require Temporal mode."));
+  }
+  const destination = await requireExternalDestination(input.destinationId, input.teamId);
+  assertPostgresMajor(input.postgresMajor);
+  try {
+    const identity = await createExternalS3Adapter(toExternalS3Destination(destination)).headObject(
+      input.objectKey
+    );
+    const existing = await findArtifactByIdentity(
+      destination.id,
+      identity.key,
+      identity.versionId,
+      identity.etag
+    );
+    const artifact =
+      existing ??
+      (
+        await db
+          .insert(externalBackupArtifacts)
+          .values({
+            id: id(),
+            teamId: input.teamId,
+            destinationId: destination.id,
+            objectKey: identity.key,
+            objectVersion: identity.versionId,
+            objectEtag: identity.etag,
+            sizeBytes: String(identity.size),
+            contentType: identity.contentType,
+            lastModified: identity.lastModified,
+            sourcePostgresVersion: input.postgresMajor,
+            status: "registering",
+            registeredByUserId: input.actor.userId,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          })
+          .returning()
+      )[0];
+    if (!artifact) throw new Error("External backup artifact could not be registered.");
+
+    if (existing?.status === "failed") {
+      const [requeued] = await db
+        .update(externalBackupArtifacts)
+        .set({
+          status: "registering",
+          registerError: null,
+          sourcePostgresVersion: input.postgresMajor,
+          registeredByUserId: input.actor.userId,
+          updatedAt: new Date()
+        })
+        .where(eq(externalBackupArtifacts.id, existing.id))
+        .returning();
+      if (!requeued) throw new Error("External backup artifact retry could not be queued.");
+      Object.assign(artifact, requeued);
+    }
+
+    let workflowId = buildExternalArtifactImportWorkflowId(artifact.id);
+    if (artifact.status === "registering") {
+      workflowId = (
+        await startExternalArtifactImportWorkflow({
+          artifactId: artifact.id,
+          destinationUpdatedAt: destination.updatedAt.toISOString()
+        })
+      ).workflowId;
+    }
+    await writeExternalBackupArtifactAudit({
+      actor: input.actor,
+      teamId: input.teamId,
+      destinationId: destination.id,
+      artifactId: artifact.id,
+      objectKey: identity.key,
+      action: existing ? "external-artifact.import.reused" : "external-artifact.import.queued",
+      permissionScope: "backup:restore",
+      outcome: "success",
+      detail: "Queued external PostgreSQL backup artifact registration."
+    });
+    return {
+      artifact: toExternalBackupArtifactView(artifact, destination.name),
+      workflowId,
+      nextAction: "test-restore" as const
+    };
+  } catch (error) {
+    await writeExternalBackupArtifactAudit({
+      actor: input.actor,
+      teamId: input.teamId,
+      destinationId: input.destinationId,
+      objectKey: input.objectKey,
+      action: "external-artifact.import.denied",
+      permissionScope: "backup:restore",
+      outcome: "denied",
+      detail: "External PostgreSQL backup artifact registration was denied."
+    });
+    throw asExternalArtifactError(error);
+  }
+}
+
+export async function triggerExternalArtifactTestRestore(input: {
+  artifactId: string;
+  teamId: string;
+  actor: ExternalArtifactActor;
+}) {
+  if (!isTemporalEnabled()) {
+    throw asExternalArtifactError(
+      new Error("External artifact verification requires Temporal mode.")
+    );
+  }
+  const resolved = await resolveExternalArtifact(input.artifactId, input.teamId);
+  if (!resolved || resolved.artifact.status !== "registered") {
+    throw asExternalArtifactError(
+      new Error("External artifact is not eligible for isolated verification.")
+    );
+  }
+  const restoreId = id();
+  const now = new Date();
+  const restore = await db.transaction(async (tx) => {
+    const [claimed] = await tx
+      .update(externalBackupArtifacts)
+      .set({ status: "verifying", registerError: null, updatedAt: now })
+      .where(
+        and(
+          eq(externalBackupArtifacts.id, resolved.artifact.id),
+          eq(externalBackupArtifacts.teamId, input.teamId),
+          eq(externalBackupArtifacts.status, "registered")
+        )
+      )
+      .returning({ id: externalBackupArtifacts.id });
+    if (!claimed) return null;
+    const [created] = await tx
+      .insert(backupRestores)
+      .values({
+        id: restoreId,
+        backupRunId: null,
+        externalArtifactId: resolved.artifact.id,
+        targetVolumeId: null,
+        mode: "verification",
+        status: "queued",
+        targetPath: null,
+        triggeredByUserId: input.actor.userId,
+        startedAt: now,
+        createdAt: now
+      })
+      .returning();
+    return created ?? null;
+  });
+  if (!restore) {
+    throw asExternalArtifactError(
+      new Error("External artifact verification is already queued or running.")
+    );
+  }
+  try {
+    await startExternalArtifactVerificationWorkflow({
+      artifactId: resolved.artifact.id,
+      restoreId
+    });
+  } catch (error) {
+    await db.transaction(async (tx) => {
+      await tx
+        .update(backupRestores)
+        .set({
+          status: "failed",
+          error: "Verification workflow could not be started.",
+          completedAt: new Date()
+        })
+        .where(eq(backupRestores.id, restoreId));
+      await tx
+        .update(externalBackupArtifacts)
+        .set({ status: "registered", updatedAt: new Date() })
+        .where(
+          and(
+            eq(externalBackupArtifacts.id, resolved.artifact.id),
+            eq(externalBackupArtifacts.status, "verifying")
+          )
+        );
+    });
+    throw asExternalArtifactError(error);
+  }
+  await writeExternalBackupArtifactAudit({
+    actor: input.actor,
+    teamId: input.teamId,
+    destinationId: resolved.destination.id,
+    artifactId: resolved.artifact.id,
+    objectKey: resolved.artifact.objectKey,
+    action: "external-artifact.verify.queued",
+    permissionScope: "backup:restore",
+    outcome: "success",
+    detail: "Queued an isolated external PostgreSQL backup artifact verification."
+  });
+  return {
+    id: restore.id,
+    artifactId: restore.externalArtifactId ?? resolved.artifact.id,
+    status: restore.status
+  };
+}
+
+async function findArtifactByIdentity(
+  destinationId: string,
+  objectKey: string,
+  objectVersion: string | null,
+  objectEtag: string | null
+) {
+  const where = objectVersion
+    ? and(
+        eq(externalBackupArtifacts.destinationId, destinationId),
+        eq(externalBackupArtifacts.objectKey, objectKey),
+        eq(externalBackupArtifacts.objectVersion, objectVersion)
+      )
+    : objectEtag
+      ? and(
+          eq(externalBackupArtifacts.destinationId, destinationId),
+          eq(externalBackupArtifacts.objectKey, objectKey),
+          isNull(externalBackupArtifacts.objectVersion),
+          eq(externalBackupArtifacts.objectEtag, objectEtag)
+        )
+      : undefined;
+  if (!where) return null;
+  const [artifact] = await db.select().from(externalBackupArtifacts).where(where).limit(1);
+  return artifact ?? null;
+}

--- a/packages/server/src/db/services/external-backup-artifact-restore-approval.ts
+++ b/packages/server/src/db/services/external-backup-artifact-restore-approval.ts
@@ -1,0 +1,276 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "../connection";
+import { approvalRequests } from "../schema/audit";
+import { backupRestores } from "../schema/storage";
+import { startExternalArtifactRestoreWorkflow } from "../../worker";
+import { isTemporalEnabled } from "../../worker/temporal/temporal-config";
+import type {
+  ExternalArtifactRestoreApproval,
+  ExternalArtifactRestoreApprovalSnapshot
+} from "../../worker/temporal/external-artifact-workflow-input";
+import { writeExternalBackupArtifactAudit } from "./external-backup-artifact-audit";
+import {
+  ExternalBackupArtifactError,
+  toExternalBackupArtifactView,
+  type ExternalArtifactActor
+} from "./external-backup-artifact-shared";
+import { resolveExternalArtifactRestoreTarget } from "./external-backup-artifact-read";
+import { readString } from "./json-helpers";
+
+type ResolvedExternalRestoreTarget = NonNullable<
+  Awaited<ReturnType<typeof resolveExternalArtifactRestoreTarget>>
+>;
+
+export async function buildExternalArtifactRestorePlan(input: {
+  artifactId: string;
+  targetVolumeId: string;
+  teamId: string;
+}) {
+  const target = await resolveExternalArtifactRestoreTarget(input);
+  if (!target) return null;
+  const artifact = toExternalBackupArtifactView(target.artifact, target.destination.name);
+  const isReady = target.artifact.status === "verified" && Boolean(target.artifact.verifiedAt);
+  return {
+    isReady,
+    artifact,
+    target: {
+      id: target.volume.id,
+      name: target.volume.name,
+      serverId: target.volume.serverId,
+      mountPath: target.volume.mountPath,
+      databaseEngine: "postgres" as const,
+      databaseName: target.databaseName,
+      databaseUser: target.databaseUser
+    },
+    preflightChecks: [
+      {
+        status: isReady ? ("ok" as const) : ("warn" as const),
+        detail: isReady
+          ? "The external artifact passed isolated PostgreSQL restore verification."
+          : "The external artifact must pass isolated verification before production restore."
+      },
+      {
+        status: "ok" as const,
+        detail: "The target volume belongs to this team and declares PostgreSQL database metadata."
+      },
+      {
+        status: "ok" as const,
+        detail: "Production restore will require a durable approval before it is queued."
+      }
+    ],
+    steps: [
+      "Confirm the selected external artifact and its isolated verification result.",
+      "Request an approval for this exact artifact and target volume.",
+      "After approval, download the pinned object again and restore it to the selected PostgreSQL target."
+    ],
+    approvalRequest: {
+      actionType: "external-artifact-restore" as const,
+      artifactId: target.artifact.id,
+      targetVolumeId: target.volume.id,
+      reason:
+        "Describe why restoring this verified external PostgreSQL artifact is safe and necessary."
+    }
+  };
+}
+
+export async function queueExternalArtifactRestore(input: {
+  artifactId: string;
+  targetVolumeId: string;
+  teamId: string;
+  actor: ExternalArtifactActor;
+  approvalRequestId: string;
+  approvalDispatchId: string;
+  operationId: string;
+  approvalSnapshot: Record<string, unknown>;
+  preserveDispatchRetry?: boolean;
+}) {
+  if (!isTemporalEnabled())
+    throw new ExternalBackupArtifactError("External restore requires Temporal mode.");
+  const target = await resolveExternalArtifactRestoreTarget(input);
+  if (!target || target.artifact.status !== "verified" || !target.artifact.sha256) return null;
+  const approval = await resolveExternalRestoreApproval(input, target);
+  if (!approval) return null;
+
+  const now = new Date();
+  const restore = await db.transaction(async (tx) => {
+    const [created] = await tx
+      .insert(backupRestores)
+      .values({
+        id: input.operationId,
+        backupRunId: null,
+        externalArtifactId: target.artifact.id,
+        targetVolumeId: target.volume.id,
+        mode: "restore",
+        status: "queued",
+        targetPath: target.volume.mountPath,
+        triggeredByUserId: input.actor.userId,
+        startedAt: now,
+        createdAt: now
+      })
+      .onConflictDoNothing()
+      .returning();
+    const persisted =
+      created ??
+      (
+        await tx
+          .select()
+          .from(backupRestores)
+          .where(eq(backupRestores.id, input.operationId))
+          .limit(1)
+      )[0];
+    if (
+      !persisted ||
+      persisted.externalArtifactId !== target.artifact.id ||
+      persisted.targetVolumeId !== target.volume.id ||
+      persisted.mode !== "restore"
+    ) {
+      throw new ExternalBackupArtifactError(
+        "Restore operation is already bound to a different target."
+      );
+    }
+    return persisted;
+  });
+
+  try {
+    const workflow = await startExternalArtifactRestoreWorkflow({
+      artifactId: target.artifact.id,
+      restoreId: restore.id,
+      targetVolumeId: target.volume.id,
+      approval
+    });
+    await writeExternalBackupArtifactAudit({
+      actor: input.actor,
+      teamId: input.teamId,
+      destinationId: target.destination.id,
+      artifactId: target.artifact.id,
+      objectKey: target.artifact.objectKey,
+      action: "external-artifact.restore.queued",
+      permissionScope: "backup:restore",
+      outcome: "success",
+      detail: "Queued approved external PostgreSQL backup artifact restore."
+    });
+    return { ...restore, workflowId: workflow.workflowId };
+  } catch (error) {
+    if (input.preserveDispatchRetry) throw error;
+    await db
+      .update(backupRestores)
+      .set({
+        status: "failed",
+        error: "Restore workflow could not be started.",
+        completedAt: new Date()
+      })
+      .where(eq(backupRestores.id, restore.id));
+    throw error;
+  }
+}
+
+export function buildExternalRestoreApprovalSnapshot(
+  target: ResolvedExternalRestoreTarget
+): ExternalArtifactRestoreApprovalSnapshot {
+  return {
+    artifactId: target.artifact.id,
+    artifactSha256: target.artifact.sha256 ?? "",
+    artifactObjectKey: target.artifact.objectKey,
+    artifactObjectVersion: target.artifact.objectVersion ?? "",
+    artifactObjectEtag: target.artifact.objectEtag ?? "",
+    artifactVerifiedAt: target.artifact.verifiedAt?.toISOString() ?? "",
+    destinationId: target.destination.id,
+    destinationUpdatedAt: target.destination.updatedAt.toISOString(),
+    targetVolumeId: target.volume.id,
+    targetVolumeUpdatedAt: target.volume.updatedAt.toISOString(),
+    targetServerId: target.volume.serverId,
+    targetMountPath: target.volume.mountPath,
+    targetServiceId: target.targetServiceId,
+    targetServiceUpdatedAt: target.targetServiceUpdatedAt,
+    runtimeServiceName: target.runtimeServiceName,
+    databaseEngine: "postgres",
+    databaseName: target.databaseName,
+    databaseUser: target.databaseUser,
+    secretPolicy: "destination-credentials-encrypted"
+  };
+}
+
+async function resolveExternalRestoreApproval(
+  input: Parameters<typeof queueExternalArtifactRestore>[0],
+  target: ResolvedExternalRestoreTarget
+): Promise<ExternalArtifactRestoreApproval | null> {
+  const snapshot = readExternalRestoreApprovalSnapshot(input.approvalSnapshot);
+  if (!snapshot) return null;
+  const [request] = await db
+    .select({ id: approvalRequests.id })
+    .from(approvalRequests)
+    .where(
+      and(
+        eq(approvalRequests.id, input.approvalRequestId),
+        eq(approvalRequests.teamId, input.teamId),
+        eq(approvalRequests.actionType, "external-artifact-restore"),
+        eq(approvalRequests.targetResource, `external-backup-artifact/${input.artifactId}`),
+        eq(approvalRequests.status, "approved")
+      )
+    )
+    .limit(1);
+  if (!request || !externalRestoreSnapshotMatches(snapshot, target)) return null;
+  return { approvalRequestId: request.id, expectedTeamId: input.teamId, snapshot };
+}
+
+function readExternalRestoreApprovalSnapshot(
+  value: Record<string, unknown>
+): ExternalArtifactRestoreApprovalSnapshot | null {
+  const read = (key: string) => readString(value, key);
+  const snapshot = {
+    artifactId: read("artifactId"),
+    artifactSha256: read("artifactSha256"),
+    artifactObjectKey: read("artifactObjectKey"),
+    artifactObjectVersion: read("artifactObjectVersion"),
+    artifactObjectEtag: read("artifactObjectEtag"),
+    artifactVerifiedAt: read("artifactVerifiedAt"),
+    destinationId: read("destinationId"),
+    destinationUpdatedAt: read("destinationUpdatedAt"),
+    targetVolumeId: read("targetVolumeId"),
+    targetVolumeUpdatedAt: read("targetVolumeUpdatedAt"),
+    targetServerId: read("targetServerId"),
+    targetMountPath: read("targetMountPath"),
+    targetServiceId: read("targetServiceId"),
+    targetServiceUpdatedAt: read("targetServiceUpdatedAt"),
+    runtimeServiceName: read("runtimeServiceName"),
+    databaseEngine: read("databaseEngine"),
+    databaseName: read("databaseName"),
+    databaseUser: read("databaseUser"),
+    secretPolicy: read("secretPolicy")
+  };
+  const required = [
+    snapshot.artifactId,
+    snapshot.artifactSha256,
+    snapshot.artifactObjectKey,
+    snapshot.artifactVerifiedAt,
+    snapshot.destinationId,
+    snapshot.destinationUpdatedAt,
+    snapshot.targetVolumeId,
+    snapshot.targetVolumeUpdatedAt,
+    snapshot.targetServerId,
+    snapshot.targetMountPath,
+    snapshot.targetServiceId,
+    snapshot.targetServiceUpdatedAt,
+    snapshot.runtimeServiceName,
+    snapshot.databaseEngine,
+    snapshot.databaseName,
+    snapshot.databaseUser,
+    snapshot.secretPolicy
+  ];
+  if (
+    required.some((item) => !item) ||
+    (!snapshot.artifactObjectVersion && !snapshot.artifactObjectEtag) ||
+    snapshot.databaseEngine !== "postgres" ||
+    snapshot.secretPolicy !== "destination-credentials-encrypted"
+  ) {
+    return null;
+  }
+  return snapshot as ExternalArtifactRestoreApprovalSnapshot;
+}
+
+function externalRestoreSnapshotMatches(
+  snapshot: ExternalArtifactRestoreApprovalSnapshot,
+  target: ResolvedExternalRestoreTarget
+) {
+  return JSON.stringify(snapshot) === JSON.stringify(buildExternalRestoreApprovalSnapshot(target));
+}

--- a/packages/server/src/db/services/external-backup-artifact-restore-approval.ts
+++ b/packages/server/src/db/services/external-backup-artifact-restore-approval.ts
@@ -272,5 +272,8 @@ function externalRestoreSnapshotMatches(
   snapshot: ExternalArtifactRestoreApprovalSnapshot,
   target: ResolvedExternalRestoreTarget
 ) {
-  return JSON.stringify(snapshot) === JSON.stringify(buildExternalRestoreApprovalSnapshot(target));
+  const current = buildExternalRestoreApprovalSnapshot(target);
+  return (Object.keys(current) as Array<keyof ExternalArtifactRestoreApprovalSnapshot>).every(
+    (key) => snapshot[key] === current[key]
+  );
 }

--- a/packages/server/src/db/services/external-backup-artifact-shared.ts
+++ b/packages/server/src/db/services/external-backup-artifact-shared.ts
@@ -1,0 +1,105 @@
+import type { AppRole } from "@daoflow/shared";
+import { and, eq } from "drizzle-orm";
+import { db } from "../connection";
+import { backupDestinations } from "../schema/destinations";
+import { externalBackupArtifacts } from "../schema/external-backup-artifacts";
+import { toDestinationConfig } from "./destination-shared";
+import type { ExternalS3Destination } from "../../worker/external-backup-s3";
+
+export type ExternalArtifactActor = { userId: string; email: string; role: AppRole };
+export type ExternalArtifactRow = typeof externalBackupArtifacts.$inferSelect;
+export type ExternalDestinationRow = typeof backupDestinations.$inferSelect;
+
+export class ExternalBackupArtifactError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExternalBackupArtifactError";
+  }
+}
+
+export function toExternalBackupArtifactView(
+  artifact: ExternalArtifactRow,
+  destinationName: string
+) {
+  return {
+    id: artifact.id,
+    origin: "external" as const,
+    destinationId: artifact.destinationId,
+    destinationName,
+    objectKey: artifact.objectKey,
+    objectVersion: artifact.objectVersion,
+    objectEtag: artifact.objectEtag,
+    sizeBytes: Number(artifact.sizeBytes),
+    sha256: artifact.sha256,
+    artifactFormat: artifact.archiveFormat,
+    databaseEngineVersion: artifact.sourcePostgresVersion,
+    status: artifact.status,
+    error: artifact.registerError,
+    registeredAt: artifact.registeredAt?.toISOString() ?? null,
+    updatedAt: artifact.updatedAt.toISOString(),
+    verifiedAt: artifact.verifiedAt?.toISOString() ?? null,
+    latestVerification: artifact.latestVerification ?? null
+  };
+}
+
+export async function requireExternalDestination(destinationId: string, teamId: string) {
+  const [destination] = await db
+    .select()
+    .from(backupDestinations)
+    .where(and(eq(backupDestinations.id, destinationId), eq(backupDestinations.teamId, teamId)))
+    .limit(1);
+  if (!destination) throw new ExternalBackupArtifactError("Destination not found.");
+  return destination;
+}
+
+export async function resolveExternalArtifact(artifactId: string, teamId: string) {
+  const [row] = await db
+    .select({ artifact: externalBackupArtifacts, destination: backupDestinations })
+    .from(externalBackupArtifacts)
+    .innerJoin(backupDestinations, eq(backupDestinations.id, externalBackupArtifacts.destinationId))
+    .where(
+      and(eq(externalBackupArtifacts.id, artifactId), eq(externalBackupArtifacts.teamId, teamId))
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export function toExternalS3Destination(
+  destination: ExternalDestinationRow
+): ExternalS3Destination {
+  let config;
+  try {
+    config = toDestinationConfig(destination);
+  } catch {
+    throw new ExternalBackupArtifactError(
+      "Destination credentials are unavailable for external import."
+    );
+  }
+  return {
+    id: destination.id,
+    provider: config.provider,
+    bucket: config.bucket ?? null,
+    region: config.region ?? null,
+    endpoint: config.endpoint ?? null,
+    accessKey: config.accessKey ?? null,
+    secretAccessKey: config.secretAccessKey ?? null,
+    encryptionMode: config.encryptionMode ?? "none",
+    externalImportEnabled: destination.externalImportEnabled,
+    externalImportPrefix: destination.externalImportPrefix,
+    maxExternalImportBytes: destination.maxExternalImportBytes
+  };
+}
+
+export function assertPostgresMajor(value: string): void {
+  if (!/^[1-9]\d*$/.test(value.trim())) {
+    throw new ExternalBackupArtifactError("PostgreSQL major version must be a positive integer.");
+  }
+}
+
+export function asExternalArtifactError(error: unknown): ExternalBackupArtifactError {
+  return error instanceof ExternalBackupArtifactError
+    ? error
+    : new ExternalBackupArtifactError(
+        error instanceof Error ? error.message : "External backup artifact operation failed."
+      );
+}

--- a/packages/server/src/db/services/external-backup-artifacts.test.ts
+++ b/packages/server/src/db/services/external-backup-artifacts.test.ts
@@ -1,0 +1,408 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isTemporalEnabled: vi.fn(),
+  startImport: vi.fn(),
+  startRestore: vi.fn(),
+  startVerification: vi.fn(),
+  headObject: vi.fn(),
+  listObjects: vi.fn()
+}));
+
+vi.mock("../../worker", () => ({
+  buildExternalArtifactImportWorkflowId: (artifactId: string) =>
+    `external-artifact-import-${artifactId}`,
+  startExternalArtifactImportWorkflow: mocks.startImport,
+  startExternalArtifactRestoreWorkflow: mocks.startRestore,
+  startExternalArtifactVerificationWorkflow: mocks.startVerification
+}));
+
+vi.mock("../../worker/temporal/temporal-config", () => ({
+  isTemporalEnabled: mocks.isTemporalEnabled
+}));
+
+vi.mock("../../worker/external-backup-s3", () => ({
+  createExternalS3Adapter: () => ({
+    headObject: mocks.headObject,
+    listObjects: mocks.listObjects
+  })
+}));
+
+import { db } from "../connection";
+import { approvalRequests } from "../schema/audit";
+import { backupDestinations } from "../schema/destinations";
+import { externalBackupArtifacts } from "../schema/external-backup-artifacts";
+import { environments, projects } from "../schema/projects";
+import { services } from "../schema/services";
+import { backupPolicies, backupRestores, backupRuns, volumes } from "../schema/storage";
+import { resetTestDatabaseWithControlPlane } from "../../test-db";
+import {
+  buildExternalRestoreApprovalSnapshot,
+  listExternalBackupObjects,
+  queueExternalArtifactRestore,
+  registerExternalBackupArtifact,
+  resolveExternalArtifactRestoreTarget,
+  triggerExternalArtifactTestRestore
+} from "./external-backup-artifacts";
+
+const actor = {
+  userId: "user_foundation_owner",
+  email: "owner@daoflow.local",
+  role: "owner" as const
+};
+const now = new Date("2026-07-19T00:00:00.000Z");
+const destinationId = "dest_external_artifact";
+const projectId = "proj_external_artifact";
+const environmentId = "env_external_artifact";
+const serviceId = "svc_external_artifact";
+const volumeId = "vol_external_artifact";
+const artifactId = "xart_external_artifact";
+
+async function createFixture() {
+  await db.insert(backupDestinations).values({
+    id: destinationId,
+    teamId: "team_foundation",
+    name: "External S3",
+    provider: "s3",
+    bucket: "external-backups",
+    encryptionMode: "none",
+    externalImportEnabled: true,
+    externalImportPrefix: "approved/postgres/",
+    maxExternalImportBytes: "2147483648",
+    createdAt: now,
+    updatedAt: now
+  });
+  await db.insert(projects).values({
+    id: projectId,
+    name: "External artifact target",
+    slug: projectId,
+    teamId: "team_foundation",
+    createdAt: now,
+    updatedAt: now
+  });
+  await db.insert(environments).values({
+    id: environmentId,
+    name: "Production",
+    slug: environmentId,
+    projectId,
+    config: {},
+    createdAt: now,
+    updatedAt: now
+  });
+  await db.insert(services).values({
+    id: serviceId,
+    name: "managed-postgres-service",
+    slug: serviceId,
+    projectId,
+    environmentId,
+    targetServerId: "srv_foundation_1",
+    config: {
+      managedDatabase: {
+        kind: "postgres",
+        label: "PostgreSQL",
+        templateSlug: "postgres",
+        databaseName: "appdb",
+        username: "appuser",
+        port: "5432",
+        internalPort: "5432",
+        serviceName: "managed-postgres-runtime",
+        volumeName: "postgres-data",
+        volumeId,
+        backupPolicyId: null,
+        backupType: "database",
+        backupEngine: "postgres",
+        connectionUriMasked: "postgres://appuser:[redacted]@host/appdb",
+        internalConnectionUriMasked: "postgres://appuser:[redacted]@host/appdb",
+        managedBy: "daoflow",
+        createdFrom: "managed-database"
+      }
+    },
+    createdAt: now,
+    updatedAt: now
+  });
+  await db.insert(volumes).values({
+    id: volumeId,
+    name: "postgres-data",
+    serverId: "srv_foundation_1",
+    mountPath: "/var/lib/postgresql/data",
+    metadata: { serviceId, projectId },
+    createdAt: now,
+    updatedAt: now
+  });
+  await db.insert(externalBackupArtifacts).values({
+    id: artifactId,
+    teamId: "team_foundation",
+    destinationId,
+    objectKey: "approved/postgres/app.dump",
+    objectVersion: null,
+    objectEtag: '"etag-only"',
+    sizeBytes: "3",
+    sha256: "a".repeat(64),
+    archiveFormat: "postgres-custom",
+    listingEvidence:
+      "; Format: Custom\n; Dumped from database version: 16.4\n1; 1 1 SCHEMA - public postgres",
+    sourcePostgresVersion: "16.4",
+    verifierImage: `postgres:16@sha256:${"b".repeat(64)}`,
+    status: "verified",
+    registeredByUserId: actor.userId,
+    registeredAt: now,
+    verifiedAt: now,
+    createdAt: now,
+    updatedAt: now
+  });
+}
+
+describe("external backup artifact persistence and approvals", () => {
+  beforeEach(async () => {
+    await resetTestDatabaseWithControlPlane();
+    mocks.isTemporalEnabled.mockReset();
+    mocks.isTemporalEnabled.mockReturnValue(true);
+    mocks.startImport.mockReset();
+    mocks.startImport.mockResolvedValue({ workflowId: "external-import", runId: "run-import" });
+    mocks.startRestore.mockReset();
+    mocks.startRestore.mockResolvedValue({ workflowId: "external-restore", runId: "run-restore" });
+    mocks.startVerification.mockReset();
+    mocks.startVerification.mockResolvedValue({
+      workflowId: "external-verify",
+      runId: "run-verify"
+    });
+    mocks.headObject.mockReset();
+    mocks.listObjects.mockReset();
+  });
+
+  it("returns the documented destination and verification response shapes", async () => {
+    await createFixture();
+    mocks.listObjects.mockResolvedValue({
+      prefix: "approved/postgres/",
+      objects: [
+        {
+          key: "approved/postgres/app.dump",
+          name: "app.dump",
+          size: 3,
+          lastModified: null,
+          etag: '"etag-only"',
+          versionId: null
+        }
+      ]
+    });
+
+    await expect(
+      listExternalBackupObjects({
+        destinationId,
+        teamId: "team_foundation",
+        actor
+      })
+    ).resolves.toMatchObject({
+      destination: {
+        id: destinationId,
+        name: "External S3",
+        provider: "s3",
+        externalImportEnabled: true,
+        externalImportPrefix: "approved/postgres/",
+        maxExternalImportBytes: 2147483648
+      }
+    });
+
+    await db
+      .update(externalBackupArtifacts)
+      .set({ status: "registered", verifiedAt: null })
+      .where(eq(externalBackupArtifacts.id, artifactId));
+    await expect(
+      triggerExternalArtifactTestRestore({ artifactId, teamId: "team_foundation", actor })
+    ).resolves.toEqual({ id: expect.any(String), artifactId, status: "queued" });
+  });
+
+  it("atomically allows only one isolated verification request", async () => {
+    await createFixture();
+    await db
+      .update(externalBackupArtifacts)
+      .set({ status: "registered", verifiedAt: null })
+      .where(eq(externalBackupArtifacts.id, artifactId));
+
+    const results = await Promise.allSettled([
+      triggerExternalArtifactTestRestore({ artifactId, teamId: "team_foundation", actor }),
+      triggerExternalArtifactTestRestore({ artifactId, teamId: "team_foundation", actor })
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    expect(mocks.startVerification).toHaveBeenCalledTimes(1);
+    const restores = await db.select().from(backupRestores);
+    expect(restores.filter((restore) => restore.externalArtifactId === artifactId)).toHaveLength(1);
+  });
+
+  it("resolves a managed PostgreSQL target from service configuration and scopes it to the team", async () => {
+    await createFixture();
+    const target = await resolveExternalArtifactRestoreTarget({
+      artifactId,
+      targetVolumeId: volumeId,
+      teamId: "team_foundation"
+    });
+    expect(target).toMatchObject({
+      databaseName: "appdb",
+      databaseUser: "appuser",
+      runtimeServiceName: "managed-postgres-runtime",
+      targetServiceId: serviceId
+    });
+    await expect(
+      resolveExternalArtifactRestoreTarget({
+        artifactId,
+        targetVolumeId: volumeId,
+        teamId: "team_other"
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("accepts ETag-only approval snapshots and invalidates them when the managed runtime changes", async () => {
+    await createFixture();
+    const target = await resolveExternalArtifactRestoreTarget({
+      artifactId,
+      targetVolumeId: volumeId,
+      teamId: "team_foundation"
+    });
+    if (!target) throw new Error("Expected managed target.");
+    const snapshot = buildExternalRestoreApprovalSnapshot(target);
+    expect(snapshot.artifactObjectVersion).toBe("");
+    expect(snapshot.artifactObjectEtag).toBe('"etag-only"');
+    await db.insert(approvalRequests).values({
+      id: "apr_external_artifact",
+      teamId: "team_foundation",
+      actionType: "external-artifact-restore",
+      targetResource: `external-backup-artifact/${artifactId}`,
+      status: "approved",
+      requestedByUserId: actor.userId,
+      requestedByEmail: actor.email,
+      requestedByRole: actor.role,
+      resolvedByUserId: actor.userId,
+      resolvedByEmail: actor.email,
+      createdAt: now,
+      resolvedAt: now
+    });
+    await expect(
+      queueExternalArtifactRestore({
+        artifactId,
+        targetVolumeId: volumeId,
+        teamId: "team_foundation",
+        actor,
+        approvalRequestId: "apr_external_artifact",
+        approvalDispatchId: "apd_external_artifact",
+        operationId: "brest_external_artifact",
+        approvalSnapshot: { ...snapshot },
+        preserveDispatchRetry: true
+      })
+    ).resolves.toMatchObject({ id: "brest_external_artifact", status: "queued" });
+    expect(mocks.startRestore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetVolumeId: volumeId,
+        approval: expect.objectContaining({ snapshot })
+      })
+    );
+
+    await db
+      .update(services)
+      .set({ updatedAt: new Date("2026-07-20T00:00:00.000Z") })
+      .where(eq(services.id, serviceId));
+    await expect(
+      queueExternalArtifactRestore({
+        artifactId,
+        targetVolumeId: volumeId,
+        teamId: "team_foundation",
+        actor,
+        approvalRequestId: "apr_external_artifact",
+        approvalDispatchId: "apd_external_artifact_2",
+        operationId: "brest_external_artifact_2",
+        approvalSnapshot: { ...snapshot },
+        preserveDispatchRetry: true
+      })
+    ).resolves.toBeNull();
+  });
+
+  it("keeps legacy backup-run restores valid and rejects malformed external source/target combinations", async () => {
+    await createFixture();
+    await db.insert(backupPolicies).values({
+      id: "bpol_external_legacy",
+      name: "Legacy policy",
+      volumeId,
+      backupType: "database",
+      databaseEngine: "postgres",
+      retentionDays: 7,
+      status: "active",
+      createdAt: now,
+      updatedAt: now
+    });
+    await db.insert(backupRuns).values({
+      id: "brun_external_legacy",
+      policyId: "bpol_external_legacy",
+      status: "succeeded",
+      artifactPath: "legacy.dump",
+      createdAt: now
+    });
+    await expect(
+      db.insert(backupRestores).values({
+        id: "brest_external_legacy",
+        backupRunId: "brun_external_legacy",
+        externalArtifactId: null,
+        targetVolumeId: null,
+        mode: "restore",
+        status: "queued",
+        createdAt: now
+      })
+    ).resolves.toBeDefined();
+    await expect(
+      db.insert(backupRestores).values({
+        id: "brest_external_invalid",
+        backupRunId: null,
+        externalArtifactId: artifactId,
+        targetVolumeId: null,
+        mode: "restore",
+        status: "queued",
+        createdAt: now
+      })
+    ).rejects.toThrow();
+    await db
+      .update(externalBackupArtifacts)
+      .set({ status: "registered", verifiedAt: null })
+      .where(eq(externalBackupArtifacts.id, artifactId));
+    await expect(
+      triggerExternalArtifactTestRestore({ artifactId, teamId: "team_foundation", actor })
+    ).resolves.toMatchObject({ status: "queued" });
+  });
+
+  it("retries the same failed pinned identity without creating a duplicate artifact", async () => {
+    await createFixture();
+    await db
+      .update(externalBackupArtifacts)
+      .set({
+        status: "failed",
+        sha256: null,
+        listingEvidence: null,
+        verifierImage: null,
+        registeredAt: null
+      })
+      .where(eq(externalBackupArtifacts.id, artifactId));
+    mocks.headObject.mockResolvedValue({
+      key: "approved/postgres/app.dump",
+      versionId: null,
+      etag: '"etag-only"',
+      size: 3,
+      contentType: null,
+      lastModified: null
+    });
+    await expect(
+      registerExternalBackupArtifact({
+        destinationId,
+        objectKey: "approved/postgres/app.dump",
+        postgresMajor: "16",
+        teamId: "team_foundation",
+        actor
+      })
+    ).resolves.toMatchObject({ nextAction: "test-restore", workflowId: "external-import" });
+    const rows = await db.select().from(externalBackupArtifacts);
+    expect(rows.filter((row) => row.objectKey === "approved/postgres/app.dump")).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ id: artifactId, status: "registering", registerError: null });
+    expect(mocks.startImport).toHaveBeenCalledWith(
+      expect.objectContaining({ artifactId, destinationUpdatedAt: now.toISOString() })
+    );
+  });
+});

--- a/packages/server/src/db/services/external-backup-artifacts.test.ts
+++ b/packages/server/src/db/services/external-backup-artifacts.test.ts
@@ -263,6 +263,7 @@ describe("external backup artifact persistence and approvals", () => {
     });
     if (!target) throw new Error("Expected managed target.");
     const snapshot = buildExternalRestoreApprovalSnapshot(target);
+    const reorderedSnapshot = Object.fromEntries(Object.entries(snapshot).reverse());
     expect(snapshot.artifactObjectVersion).toBe("");
     expect(snapshot.artifactObjectEtag).toBe('"etag-only"');
     await db.insert(approvalRequests).values({
@@ -288,7 +289,7 @@ describe("external backup artifact persistence and approvals", () => {
         approvalRequestId: "apr_external_artifact",
         approvalDispatchId: "apd_external_artifact",
         operationId: "brest_external_artifact",
-        approvalSnapshot: { ...snapshot },
+        approvalSnapshot: reorderedSnapshot,
         preserveDispatchRetry: true
       })
     ).resolves.toMatchObject({ id: "brest_external_artifact", status: "queued" });

--- a/packages/server/src/db/services/external-backup-artifacts.ts
+++ b/packages/server/src/db/services/external-backup-artifacts.ts
@@ -1,0 +1,22 @@
+export {
+  ExternalBackupArtifactError,
+  asExternalArtifactError,
+  toExternalBackupArtifactView,
+  type ExternalArtifactActor
+} from "./external-backup-artifact-shared";
+export {
+  getExternalBackupArtifact,
+  listExternalBackupArtifacts,
+  resolveExternalArtifactRestoreTarget,
+  resolveExternalPostgresTargetMetadata
+} from "./external-backup-artifact-read";
+export {
+  listExternalBackupObjects,
+  registerExternalBackupArtifact,
+  triggerExternalArtifactTestRestore
+} from "./external-backup-artifact-registration";
+export {
+  buildExternalArtifactRestorePlan,
+  buildExternalRestoreApprovalSnapshot,
+  queueExternalArtifactRestore
+} from "./external-backup-artifact-restore-approval";

--- a/packages/server/src/db/services/external-import-settings.test.ts
+++ b/packages/server/src/db/services/external-import-settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_EXTERNAL_IMPORT_MAX_BYTES,
+  normalizeExternalImportSettings
+} from "./external-import-settings";
+
+const enabledS3 = {
+  externalImportEnabled: true,
+  externalImportPrefix: "approved/postgres",
+  maxExternalImportBytes: String(DEFAULT_EXTERNAL_IMPORT_MAX_BYTES),
+  provider: "s3",
+  encryptionMode: "none"
+};
+
+describe("external destination import settings", () => {
+  it("defaults imports to disabled and normalizes an enabled prefix", () => {
+    expect(normalizeExternalImportSettings({ provider: "s3", encryptionMode: "none" })).toEqual({
+      externalImportEnabled: false,
+      externalImportPrefix: null,
+      maxExternalImportBytes: String(DEFAULT_EXTERNAL_IMPORT_MAX_BYTES)
+    });
+    expect(normalizeExternalImportSettings(enabledS3)).toMatchObject({
+      externalImportEnabled: true,
+      externalImportPrefix: "approved/postgres/"
+    });
+  });
+
+  it("rejects enabled imports for non-S3 or encrypted effective destinations", () => {
+    expect(() => normalizeExternalImportSettings({ ...enabledS3, provider: "sftp" })).toThrow(
+      "S3-compatible"
+    );
+    expect(() =>
+      normalizeExternalImportSettings({ ...enabledS3, encryptionMode: "archive-zip" })
+    ).toThrow("encryption mode none");
+    expect(() =>
+      normalizeExternalImportSettings(
+        { externalImportEnabled: true },
+        { ...enabledS3, externalImportPrefix: "approved/postgres/" }
+      )
+    ).not.toThrow();
+    expect(() =>
+      normalizeExternalImportSettings(
+        { externalImportEnabled: true, encryptionMode: "rclone-crypt" },
+        { ...enabledS3, externalImportPrefix: "approved/postgres/" }
+      )
+    ).toThrow("encryption mode none");
+  });
+});

--- a/packages/server/src/db/services/external-import-settings.ts
+++ b/packages/server/src/db/services/external-import-settings.ts
@@ -1,0 +1,98 @@
+export const DEFAULT_EXTERNAL_IMPORT_MAX_BYTES = 2 * 1024 * 1024 * 1024;
+export const MIN_EXTERNAL_IMPORT_BYTES = 1024 * 1024;
+export const MAX_EXTERNAL_IMPORT_BYTES = DEFAULT_EXTERNAL_IMPORT_MAX_BYTES;
+
+type ExistingExternalImportSettings = {
+  externalImportEnabled: boolean;
+  externalImportPrefix: string | null;
+  maxExternalImportBytes: string;
+  provider: string;
+  encryptionMode: string;
+};
+
+type ExternalImportSettingsInput = {
+  externalImportEnabled?: boolean;
+  externalImportPrefix?: string | null;
+  maxExternalImportBytes?: number | string | null;
+  provider?: string;
+  encryptionMode?: string;
+};
+
+export function normalizeExternalImportPrefix(value: string): string {
+  const raw = value.trim();
+  const trimmed = raw.endsWith("/") ? raw.slice(0, -1) : raw;
+  if (!trimmed || trimmed.length > 1024) {
+    throw new Error("External import prefix must contain between 1 and 1024 characters.");
+  }
+  if (raw.endsWith("//")) {
+    throw new Error("External import prefix must not contain empty path segments.");
+  }
+  if (trimmed.includes("\\") || hasControlCharacter(trimmed)) {
+    throw new Error("External import prefix contains unsupported characters.");
+  }
+
+  const parts = trimmed.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) {
+    throw new Error("External import prefix must not contain empty or traversal path segments.");
+  }
+
+  return `${parts.join("/")}/`;
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
+export function normalizeExternalImportSettings(
+  input: ExternalImportSettingsInput,
+  existing?: ExistingExternalImportSettings
+) {
+  const externalImportEnabled =
+    input.externalImportEnabled ?? existing?.externalImportEnabled ?? false;
+  const rawPrefix =
+    input.externalImportPrefix === undefined
+      ? (existing?.externalImportPrefix ?? null)
+      : input.externalImportPrefix;
+  const externalImportPrefix = rawPrefix === null ? null : normalizeExternalImportPrefix(rawPrefix);
+  const rawMax =
+    input.maxExternalImportBytes === undefined
+      ? (existing?.maxExternalImportBytes ?? DEFAULT_EXTERNAL_IMPORT_MAX_BYTES)
+      : input.maxExternalImportBytes;
+  const maxExternalImportBytes = normalizeExternalImportBytes(rawMax);
+
+  if (externalImportEnabled && !externalImportPrefix) {
+    throw new Error("External imports require a non-empty approved object prefix.");
+  }
+  const provider = input.provider ?? existing?.provider;
+  const encryptionMode = input.encryptionMode ?? existing?.encryptionMode ?? "none";
+  if (externalImportEnabled && provider !== "s3") {
+    throw new Error("External imports require an S3-compatible destination.");
+  }
+  if (externalImportEnabled && encryptionMode !== "none") {
+    throw new Error("External imports require destination encryption mode none.");
+  }
+
+  return { externalImportEnabled, externalImportPrefix, maxExternalImportBytes };
+}
+
+export function normalizeExternalImportBytes(value: number | string | null): string {
+  const numeric =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && /^\d+$/.test(value)
+        ? Number(value)
+        : Number.NaN;
+  if (
+    !Number.isSafeInteger(numeric) ||
+    numeric < MIN_EXTERNAL_IMPORT_BYTES ||
+    numeric > MAX_EXTERNAL_IMPORT_BYTES
+  ) {
+    throw new Error(
+      `External import size must be an integer between ${MIN_EXTERNAL_IMPORT_BYTES} and ${MAX_EXTERNAL_IMPORT_BYTES} bytes.`
+    );
+  }
+  return String(numeric);
+}

--- a/packages/server/src/git-provider-ca-contract.test.ts
+++ b/packages/server/src/git-provider-ca-contract.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { appRouter } from "./router";
 import { resetSeededTestDatabase } from "./test-db";
 import { db } from "./db/connection";
@@ -104,7 +104,8 @@ describe("git provider CA admin contract", () => {
     const audits = await db
       .select()
       .from(auditEntries)
-      .where(eq(auditEntries.targetResource, `git_provider/${registered.id}`));
+      .where(eq(auditEntries.targetResource, `git_provider/${registered.id}`))
+      .orderBy(asc(auditEntries.id));
     expect(audits.map((entry) => entry.action)).toEqual([
       "git_provider.register",
       "git_provider.ca.update",

--- a/packages/server/src/router-types.ts
+++ b/packages/server/src/router-types.ts
@@ -1,3 +1,12 @@
 import type { appRouter } from "./router";
 
 export type AppRouter = typeof appRouter;
+
+type Assert<T extends true> = T;
+type AppRouterProcedurePaths = keyof typeof appRouter._def.procedures;
+
+// React's tRPC client turns a broad router record into a built-in-method
+// collision union. Keep the public router's procedure paths concrete.
+type _AppRouterProcedurePathsMustRemainConcrete = Assert<
+  string extends AppRouterProcedurePaths ? false : true
+>;

--- a/packages/server/src/routes/backup-scope.ts
+++ b/packages/server/src/routes/backup-scope.ts
@@ -6,6 +6,7 @@ import { auditEntries } from "../db/schema/audit";
 import { backupPolicies, backupRuns, volumes } from "../db/schema/storage";
 import { resolveMemberTeamIdForUser } from "../db/services/teams";
 import { backupDestinations } from "../db/schema/destinations";
+import { externalBackupArtifacts } from "../db/schema/external-backup-artifacts";
 import { resolveVolumeTeamId } from "../db/services/backup-resource-team";
 
 type BackupScopeContext = {
@@ -17,7 +18,8 @@ async function recordDeniedBackupAccess(input: {
   ctx: BackupScopeContext;
   action: string;
   permissionScope: string;
-  resourceType: "backup-destination" | "backup-policy" | "backup-run" | "volume";
+  resourceType:
+    "backup-destination" | "backup-policy" | "backup-run" | "external-backup-artifact" | "volume";
 }) {
   await db.insert(auditEntries).values({
     actorType: input.ctx.auth.method === "api-token" ? "token" : "user",
@@ -136,5 +138,28 @@ export async function assertBackupRunScope(input: {
       await recordDeniedBackupAccess({ ...input, resourceType: "backup-run" });
     }
     throw error;
+  }
+}
+
+export async function assertExternalBackupArtifactScope(input: {
+  ctx: BackupScopeContext;
+  artifactId: string;
+  action: string;
+  permissionScope: string;
+}) {
+  const teamId = await requireTeamId(input.ctx.session.user.id);
+  const [artifact] = await db
+    .select({ id: externalBackupArtifacts.id })
+    .from(externalBackupArtifacts)
+    .where(
+      and(
+        eq(externalBackupArtifacts.id, input.artifactId),
+        eq(externalBackupArtifacts.teamId, teamId)
+      )
+    )
+    .limit(1);
+  if (!artifact) {
+    await recordDeniedBackupAccess({ ...input, resourceType: "external-backup-artifact" });
+    throw new TRPCError({ code: "NOT_FOUND", message: "External backup artifact not found." });
   }
 }

--- a/packages/server/src/routes/command-admin-agents-approvals.test.ts
+++ b/packages/server/src/routes/command-admin-agents-approvals.test.ts
@@ -337,4 +337,34 @@ describe("team-scoped approval routes", () => {
       linkedOwnerTokenCaller.approveApprovalRequest({ requestId: teamARequest.id })
     ).resolves.toMatchObject({ id: teamARequest.id, status: "approved" });
   });
+
+  it("requires both approval creation and backup restore scopes for external restores", async () => {
+    const input = {
+      artifactId: "xart_missing_scope_fixture",
+      targetVolumeId: "vol_missing_scope_fixture",
+      reason: "Verify the external restore scope boundary before approval."
+    };
+    const approvalOnly = appRouter.createCaller({
+      requestId: "external-restore-approval-scope-denied",
+      session: makeSession("owner"),
+      auth: makeTokenAuthContext("owner", ["approvals:create"])
+    });
+
+    await expect(approvalOnly.requestExternalArtifactRestoreApproval(input)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      cause: expect.objectContaining({
+        code: "SCOPE_DENIED",
+        requiredScopes: ["approvals:create", "backup:restore"]
+      })
+    });
+
+    const fullyScoped = appRouter.createCaller({
+      requestId: "external-restore-approval-scope-allowed",
+      session: makeSession("owner"),
+      auth: makeTokenAuthContext("owner", ["approvals:create", "backup:restore"])
+    });
+    await expect(fullyScoped.requestExternalArtifactRestoreApproval(input)).rejects.toMatchObject({
+      code: "BAD_REQUEST"
+    });
+  });
 });

--- a/packages/server/src/routes/command-admin-agents-approvals.ts
+++ b/packages/server/src/routes/command-admin-agents-approvals.ts
@@ -11,6 +11,7 @@ import {
   adminProcedure,
   approvalsCreateProcedure,
   approvalsDecideProcedure,
+  externalRestoreApprovalProcedure,
   getActorContext,
   t,
   throwOnOperationError,
@@ -110,6 +111,32 @@ export const adminAgentApprovalRouter = t.router({
         });
       }
 
+      return request;
+    }),
+
+  requestExternalArtifactRestoreApproval: externalRestoreApprovalProcedure
+    .input(
+      z.object({
+        artifactId: z.string().min(1),
+        targetVolumeId: z.string().min(1),
+        reason: z.string().min(12).max(280)
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const teamId = await requireActorTeamId(ctx.session.user.id);
+      const request = await createApprovalRequest({
+        actionType: "external-artifact-restore",
+        ...input,
+        teamId,
+        ...getActorContext(ctx)
+      });
+      if (!request) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Only verified external PostgreSQL artifacts and valid target volumes can be submitted for approval."
+        });
+      }
       return request;
     }),
 

--- a/packages/server/src/routes/command-backup-schemas.ts
+++ b/packages/server/src/routes/command-backup-schemas.ts
@@ -32,7 +32,15 @@ export const backupDestinationCreateInputSchema = z.object({
   encryptionPassword: z.string().optional(),
   encryptionSalt: z.string().optional(),
   filenameEncryption: z.enum(["standard", "obfuscate", "off"]).optional(),
-  localPath: z.string().optional()
+  localPath: z.string().optional(),
+  externalImportEnabled: z.boolean().optional(),
+  externalImportPrefix: z.string().max(1024).nullable().optional(),
+  maxExternalImportBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(2 * 1024 * 1024 * 1024)
+    .optional()
 });
 
 export const backupDestinationUpdateInputSchema = backupDestinationCreateInputSchema

--- a/packages/server/src/routes/command-backup.ts
+++ b/packages/server/src/routes/command-backup.ts
@@ -2,9 +2,11 @@ import { t } from "../trpc";
 import { backupDestinationCommandRouter } from "./command-backup-destinations";
 import { backupExecutionCommandRouter } from "./command-backup-execution";
 import { backupStorageCommandRouter } from "./command-backup-storage";
+import { externalBackupArtifactCommandRouter } from "./external-backup-artifacts";
 
 export const backupRouter = t.mergeRouters(
   backupExecutionCommandRouter,
   backupDestinationCommandRouter,
-  backupStorageCommandRouter
+  backupStorageCommandRouter,
+  externalBackupArtifactCommandRouter
 );

--- a/packages/server/src/routes/external-backup-artifacts.ts
+++ b/packages/server/src/routes/external-backup-artifacts.ts
@@ -1,0 +1,176 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import {
+  buildExternalArtifactRestorePlan,
+  getExternalBackupArtifact,
+  listExternalBackupArtifacts,
+  listExternalBackupObjects,
+  registerExternalBackupArtifact,
+  triggerExternalArtifactTestRestore
+} from "../db/services/external-backup-artifacts";
+import { backupReadProcedure, backupRestoreProcedure, getActorContext, t } from "../trpc";
+import {
+  assertBackupDestinationScope,
+  assertExternalBackupArtifactScope,
+  assertVolumeScope
+} from "./backup-scope";
+import { requireActorTeamId } from "./team-scope";
+
+const destinationIdInput = z.object({ destinationId: z.string().min(1).max(32) });
+
+export const externalBackupArtifactReadRouter = t.router({
+  externalBackupObjects: backupReadProcedure
+    .input(destinationIdInput.extend({ prefix: z.string().max(1024).optional() }))
+    .query(async ({ ctx, input }) => {
+      await assertBackupDestinationScope({
+        ctx,
+        destinationId: input.destinationId,
+        action: "external-artifact.list.denied",
+        permissionScope: "backup:read"
+      });
+      const actor = getActorContext(ctx);
+      const teamId = await requireActorTeamId(actor.requestedByUserId);
+      try {
+        return await listExternalBackupObjects({
+          ...input,
+          teamId,
+          actor: {
+            userId: actor.requestedByUserId,
+            email: actor.requestedByEmail,
+            role: actor.requestedByRole
+          }
+        });
+      } catch (error) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            error instanceof Error ? error.message : "External backup objects are unavailable."
+        });
+      }
+    }),
+  externalBackupArtifacts: backupReadProcedure
+    .input(
+      destinationIdInput.partial().extend({ limit: z.number().int().min(1).max(100).optional() })
+    )
+    .query(async ({ ctx, input }) => {
+      if (input.destinationId) {
+        await assertBackupDestinationScope({
+          ctx,
+          destinationId: input.destinationId,
+          action: "external-artifact.list.denied",
+          permissionScope: "backup:read"
+        });
+      }
+      const teamId = await requireActorTeamId(ctx.session.user.id);
+      return listExternalBackupArtifacts({ teamId, ...input });
+    }),
+  externalBackupArtifact: backupReadProcedure
+    .input(z.object({ artifactId: z.string().min(1).max(32) }))
+    .query(async ({ ctx, input }) => {
+      await assertExternalBackupArtifactScope({
+        ctx,
+        artifactId: input.artifactId,
+        action: "external-artifact.read.denied",
+        permissionScope: "backup:read"
+      });
+      const teamId = await requireActorTeamId(ctx.session.user.id);
+      const artifact = await getExternalBackupArtifact(input.artifactId, teamId);
+      if (!artifact)
+        throw new TRPCError({ code: "NOT_FOUND", message: "External backup artifact not found." });
+      return artifact;
+    }),
+  externalArtifactRestorePlan: backupReadProcedure
+    .input(
+      z.object({ artifactId: z.string().min(1).max(32), targetVolumeId: z.string().min(1).max(32) })
+    )
+    .query(async ({ ctx, input }) => {
+      await assertExternalBackupArtifactScope({
+        ctx,
+        artifactId: input.artifactId,
+        action: "external-artifact.restore-plan.denied",
+        permissionScope: "backup:read"
+      });
+      await assertVolumeScope({
+        ctx,
+        volumeId: input.targetVolumeId,
+        action: "external-artifact.restore-plan.denied",
+        permissionScope: "backup:read"
+      });
+      const teamId = await requireActorTeamId(ctx.session.user.id);
+      const plan = await buildExternalArtifactRestorePlan({ teamId, ...input });
+      if (!plan)
+        throw new TRPCError({ code: "NOT_FOUND", message: "External restore target not found." });
+      return plan;
+    })
+});
+
+export const externalBackupArtifactCommandRouter = t.router({
+  registerExternalBackupArtifact: backupRestoreProcedure
+    .input(
+      destinationIdInput.extend({
+        objectKey: z.string().min(1).max(1024),
+        postgresMajor: z.number().int().min(9).max(99)
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertBackupDestinationScope({
+        ctx,
+        destinationId: input.destinationId,
+        action: "external-artifact.import.denied",
+        permissionScope: "backup:restore"
+      });
+      const actor = getActorContext(ctx);
+      const teamId = await requireActorTeamId(actor.requestedByUserId);
+      try {
+        return await registerExternalBackupArtifact({
+          ...input,
+          postgresMajor: String(input.postgresMajor),
+          teamId,
+          actor: {
+            userId: actor.requestedByUserId,
+            email: actor.requestedByEmail,
+            role: actor.requestedByRole
+          }
+        });
+      } catch (error) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            error instanceof Error
+              ? error.message
+              : "External backup artifact could not be registered."
+        });
+      }
+    }),
+  triggerExternalArtifactTestRestore: backupRestoreProcedure
+    .input(z.object({ artifactId: z.string().min(1).max(32) }))
+    .mutation(async ({ ctx, input }) => {
+      await assertExternalBackupArtifactScope({
+        ctx,
+        artifactId: input.artifactId,
+        action: "external-artifact.verify.denied",
+        permissionScope: "backup:restore"
+      });
+      const actor = getActorContext(ctx);
+      const teamId = await requireActorTeamId(actor.requestedByUserId);
+      try {
+        return await triggerExternalArtifactTestRestore({
+          ...input,
+          teamId,
+          actor: {
+            userId: actor.requestedByUserId,
+            email: actor.requestedByEmail,
+            role: actor.requestedByRole
+          }
+        });
+      } catch (error) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            error instanceof Error
+              ? error.message
+              : "External artifact verification could not be queued."
+        });
+      }
+    })
+});

--- a/packages/server/src/routes/read.ts
+++ b/packages/server/src/routes/read.ts
@@ -38,6 +38,7 @@ import { limitInput } from "../schemas";
 import { getStartupReadiness } from "../startup-readiness";
 import { accessAssetsReadRouter } from "./read-access-assets";
 import { backupReadRouter } from "./read-backups";
+import { externalBackupArtifactReadRouter } from "./external-backup-artifacts";
 import { developmentTaskReadRouter } from "./read-development-tasks";
 import { deploymentReadRouter } from "./read-deployments";
 import { managedOperationsReadRouter } from "./read-managed-operations";
@@ -396,6 +397,7 @@ export const readRouter = t.mergeRouters(
   coreReadRouter,
   deploymentReadRouter,
   backupReadRouter,
+  externalBackupArtifactReadRouter,
   developmentTaskReadRouter,
   accessAssetsReadRouter,
   managedOperationsReadRouter,

--- a/packages/server/src/test-db-readiness.test.ts
+++ b/packages/server/src/test-db-readiness.test.ts
@@ -17,7 +17,14 @@ const currentSchema = {
   serverMetricDeliveryCooldowns: "server_metric_delivery_cooldowns",
   serverMetricOutbox: "server_metric_outbox",
   serverMetricPolicies: "server_metric_policies",
-  serverMetricStates: "server_metric_states"
+  serverMetricStates: "server_metric_states",
+  externalBackupArtifacts: "external_backup_artifacts",
+  backupRestoresExternalArtifactId: "external_artifact_id",
+  backupRestoresTargetVolumeId: "target_volume_id",
+  backupRestoresExternalTargetModeCheck: "backup_restores_external_target_mode_check",
+  backupDestinationsExternalImportEnabled: "external_import_enabled",
+  backupDestinationsExternalImportSettingsCheck:
+    "backup_destinations_external_import_settings_check"
 };
 
 describe("test database schema readiness", () => {
@@ -41,7 +48,13 @@ describe("test database schema readiness", () => {
     "serverMetricDeliveryCooldowns",
     "serverMetricOutbox",
     "serverMetricPolicies",
-    "serverMetricStates"
+    "serverMetricStates",
+    "externalBackupArtifacts",
+    "backupRestoresExternalArtifactId",
+    "backupRestoresTargetVolumeId",
+    "backupRestoresExternalTargetModeCheck",
+    "backupDestinationsExternalImportEnabled",
+    "backupDestinationsExternalImportSettingsCheck"
   ] as const)("rejects a schema missing %s", (marker) => {
     expect(
       testDatabaseSchemaTestHooks.hasLatestTestSchema({

--- a/packages/server/src/test-db.ts
+++ b/packages/server/src/test-db.ts
@@ -26,7 +26,7 @@ import { resetAuthState } from "./auth";
 
 const { Client } = pg;
 const TEST_DB_PREPARE_LOCK_ID = 8_705_231;
-const MIN_EXPECTED_PUBLIC_TABLES = 49;
+const MIN_EXPECTED_PUBLIC_TABLES = 50;
 
 interface LatestTestSchemaState {
   environmentVariablesRevision: string | null;
@@ -45,6 +45,12 @@ interface LatestTestSchemaState {
   projectVariables: string | null;
   projectVariablesRevision: string | null;
   serviceVariablesRevision: string | null;
+  externalBackupArtifacts: string | null;
+  backupRestoresExternalArtifactId: string | null;
+  backupRestoresTargetVolumeId: string | null;
+  backupRestoresExternalTargetModeCheck: string | null;
+  backupDestinationsExternalImportEnabled: string | null;
+  backupDestinationsExternalImportSettingsCheck: string | null;
 }
 
 function hasLatestTestSchema(state: LatestTestSchemaState | undefined): boolean {
@@ -64,7 +70,13 @@ function hasLatestTestSchema(state: LatestTestSchemaState | undefined): boolean 
     state.serverMetricStates &&
     state.projectVariables &&
     state.projectVariablesRevision &&
-    state.serviceVariablesRevision
+    state.serviceVariablesRevision &&
+    state.externalBackupArtifacts &&
+    state.backupRestoresExternalArtifactId &&
+    state.backupRestoresTargetVolumeId &&
+    state.backupRestoresExternalTargetModeCheck &&
+    state.backupDestinationsExternalImportEnabled &&
+    state.backupDestinationsExternalImportSettingsCheck
   );
 }
 
@@ -135,6 +147,12 @@ async function isTestSchemaReady(connectionString: string): Promise<boolean> {
       backupDestinationsTeamId: string | null;
       backupRunsArtifactCheckedAt: string | null;
       backupRestoresMode: string | null;
+      externalBackupArtifacts: string | null;
+      backupRestoresExternalArtifactId: string | null;
+      backupRestoresTargetVolumeId: string | null;
+      backupRestoresExternalTargetModeCheck: string | null;
+      backupDestinationsExternalImportEnabled: string | null;
+      backupDestinationsExternalImportSettingsCheck: string | null;
       controlPlaneRecoveryBundles: string | null;
       backupDestinationsCredentialsEncrypted: string | null;
       backupDestinationsCredentialStateCheck: string | null;
@@ -221,6 +239,12 @@ async function isTestSchemaReady(connectionString: string): Promise<boolean> {
         (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_destinations' AND column_name = 'team_id') AS "backupDestinationsTeamId",
         (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_runs' AND column_name = 'artifact_checked_at') AS "backupRunsArtifactCheckedAt",
         (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_restores' AND column_name = 'mode') AS "backupRestoresMode",
+        to_regclass('public.external_backup_artifacts') AS "externalBackupArtifacts",
+        (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_restores' AND column_name = 'external_artifact_id') AS "backupRestoresExternalArtifactId",
+        (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_restores' AND column_name = 'target_volume_id') AS "backupRestoresTargetVolumeId",
+        (SELECT conname FROM pg_constraint WHERE conname = 'backup_restores_external_target_mode_check') AS "backupRestoresExternalTargetModeCheck",
+        (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_destinations' AND column_name = 'external_import_enabled') AS "backupDestinationsExternalImportEnabled",
+        (SELECT conname FROM pg_constraint WHERE conname = 'backup_destinations_external_import_settings_check') AS "backupDestinationsExternalImportSettingsCheck",
         to_regclass('public.control_plane_recovery_bundles') AS "controlPlaneRecoveryBundles",
         (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_destinations' AND column_name = 'credentials_encrypted') AS "backupDestinationsCredentialsEncrypted",
         (SELECT conname FROM pg_constraint WHERE conname = 'backup_destinations_credentials_state_check') AS "backupDestinationsCredentialStateCheck",
@@ -418,6 +442,12 @@ async function readPoolSchemaState() {
     backupDestinationsTeamId: string | null;
     backupRunsArtifactCheckedAt: string | null;
     backupRestoresMode: string | null;
+    externalBackupArtifacts: string | null;
+    backupRestoresExternalArtifactId: string | null;
+    backupRestoresTargetVolumeId: string | null;
+    backupRestoresExternalTargetModeCheck: string | null;
+    backupDestinationsExternalImportEnabled: string | null;
+    backupDestinationsExternalImportSettingsCheck: string | null;
     controlPlaneRecoveryBundles: string | null;
     backupDestinationsCredentialsEncrypted: string | null;
     backupDestinationsCredentialStateCheck: string | null;
@@ -503,6 +533,12 @@ async function readPoolSchemaState() {
       (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_destinations' AND column_name = 'team_id') AS "backupDestinationsTeamId",
       (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_runs' AND column_name = 'artifact_checked_at') AS "backupRunsArtifactCheckedAt",
       (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_restores' AND column_name = 'mode') AS "backupRestoresMode",
+      to_regclass('public.external_backup_artifacts') AS "externalBackupArtifacts",
+      (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_restores' AND column_name = 'external_artifact_id') AS "backupRestoresExternalArtifactId",
+      (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_restores' AND column_name = 'target_volume_id') AS "backupRestoresTargetVolumeId",
+      (SELECT conname FROM pg_constraint WHERE conname = 'backup_restores_external_target_mode_check') AS "backupRestoresExternalTargetModeCheck",
+      (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_destinations' AND column_name = 'external_import_enabled') AS "backupDestinationsExternalImportEnabled",
+      (SELECT conname FROM pg_constraint WHERE conname = 'backup_destinations_external_import_settings_check') AS "backupDestinationsExternalImportSettingsCheck",
       to_regclass('public.control_plane_recovery_bundles') AS "controlPlaneRecoveryBundles",
       (SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'backup_destinations' AND column_name = 'credentials_encrypted') AS "backupDestinationsCredentialsEncrypted",
       (SELECT conname FROM pg_constraint WHERE conname = 'backup_destinations_credentials_state_check') AS "backupDestinationsCredentialStateCheck",

--- a/packages/server/src/trpc.ts
+++ b/packages/server/src/trpc.ts
@@ -217,6 +217,10 @@ export const backupRestoreProcedure = auditedScopedProcedure(ALL_OPS, ["backup:r
 export const approvalsCreateProcedure = auditedScopedProcedure(ALL_INCL_AGENT, [
   "approvals:create"
 ]);
+export const externalRestoreApprovalProcedure = auditedScopedProcedure(ALL_OPS, [
+  "approvals:create",
+  "backup:restore"
+]);
 export const approvalsDecideProcedure = auditedScopedProcedure(ALL_OPS, ["approvals:decide"]);
 export const tokensManageProcedure = auditedScopedProcedure(ADMIN_ONLY, ["tokens:manage"]);
 export const membersManageProcedure = auditedScopedProcedure(ADMIN_ONLY, ["members:manage"]);

--- a/packages/server/src/worker/external-backup-s3-stream.ts
+++ b/packages/server/src/worker/external-backup-s3-stream.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { createWriteStream, rmSync } from "node:fs";
+import { once } from "node:events";
+import { ExternalS3Error, type ExternalS3OperationHooks } from "./external-backup-s3-types";
+
+const S3_METADATA_TIMEOUT_MS = Number(
+  process.env.DAOFLOW_EXTERNAL_S3_METADATA_TIMEOUT_MS ?? 15_000
+);
+
+export async function sendS3Metadata<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  message: string
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), S3_METADATA_TIMEOUT_MS);
+  try {
+    return await run(controller.signal);
+  } catch {
+    throw new ExternalS3Error(message);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function streamPinnedObjectToFile(input: {
+  body: unknown;
+  contentLength: number | undefined;
+  expectedSize: number;
+  maxBytes: number;
+  destinationPath: string;
+  hooks: ExternalS3OperationHooks;
+}): Promise<{ sha256: string; bytes: number }> {
+  if (input.contentLength !== undefined && input.contentLength !== input.expectedSize) {
+    throw new ExternalS3Error("Pinned external backup object size changed before download.");
+  }
+  if (input.expectedSize > input.maxBytes) {
+    throw new ExternalS3Error("External backup object exceeds the configured import size limit.");
+  }
+  const body = input.body as AsyncIterable<Uint8Array> | undefined;
+  if (!body || typeof body[Symbol.asyncIterator] !== "function") {
+    throw new ExternalS3Error("Pinned external backup object has no readable response body.");
+  }
+
+  const hash = createHash("sha256");
+  let bytes = 0;
+  const output = createWriteStream(input.destinationPath, { flags: "wx", mode: 0o600 });
+  let streamError: Error | null = null;
+  const readStreamError = (): Error | null => streamError;
+  const closed = once(output, "close");
+  output.on("error", (error) => {
+    streamError = error;
+  });
+  try {
+    for await (const chunk of body) {
+      if (input.hooks.cancellationSignal?.aborted) {
+        throw new ExternalS3Error("Pinned external backup download was cancelled.");
+      }
+      input.hooks.heartbeat?.();
+      const buffer = Buffer.from(chunk);
+      bytes += buffer.byteLength;
+      if (bytes > input.maxBytes || bytes > input.expectedSize) {
+        throw new ExternalS3Error("External backup object exceeded its approved byte limit.");
+      }
+      hash.update(buffer);
+      if (!output.write(buffer)) {
+        await Promise.race([once(output, "drain"), closed]);
+        const writeError = readStreamError();
+        if (writeError) throw writeError;
+      }
+    }
+    output.end();
+    await Promise.race([once(output, "finish"), closed]);
+    const finishError = readStreamError();
+    if (finishError) throw finishError;
+  } catch (error) {
+    output.destroy();
+    await closed;
+    rmSync(input.destinationPath, { force: true });
+    if (error instanceof ExternalS3Error) throw error;
+    throw new ExternalS3Error("Pinned external backup object could not be written safely.");
+  }
+  if (bytes !== input.expectedSize) {
+    rmSync(input.destinationPath, { force: true });
+    throw new ExternalS3Error(
+      "Pinned external backup object size did not match its approved metadata."
+    );
+  }
+  return { sha256: hash.digest("hex"), bytes };
+}

--- a/packages/server/src/worker/external-backup-s3-stream.ts
+++ b/packages/server/src/worker/external-backup-s3-stream.ts
@@ -15,8 +15,8 @@ export async function sendS3Metadata<T>(
   const timeout = setTimeout(() => controller.abort(), S3_METADATA_TIMEOUT_MS);
   try {
     return await run(controller.signal);
-  } catch {
-    throw new ExternalS3Error(message);
+  } catch (error) {
+    throw new ExternalS3Error(message, { cause: error });
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/server/src/worker/external-backup-s3-types.ts
+++ b/packages/server/src/worker/external-backup-s3-types.ts
@@ -36,8 +36,8 @@ export type ExternalS3OperationHooks = {
 };
 
 export class ExternalS3Error extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "ExternalS3Error";
   }
 }

--- a/packages/server/src/worker/external-backup-s3-types.ts
+++ b/packages/server/src/worker/external-backup-s3-types.ts
@@ -1,0 +1,43 @@
+export type ExternalS3Destination = {
+  id: string;
+  provider: string;
+  bucket: string | null;
+  region: string | null;
+  endpoint: string | null;
+  accessKey: string | null;
+  secretAccessKey: string | null;
+  encryptionMode: string;
+  externalImportEnabled: boolean;
+  externalImportPrefix: string | null;
+  maxExternalImportBytes: string;
+};
+
+export type ExternalS3ObjectIdentity = {
+  key: string;
+  versionId: string | null;
+  etag: string | null;
+  size: number;
+  contentType: string | null;
+  lastModified: Date | null;
+};
+
+export type ExternalS3ObjectView = {
+  key: string;
+  name: string;
+  size: number;
+  lastModified: string | null;
+  etag: string | null;
+  versionId: string | null;
+};
+
+export type ExternalS3OperationHooks = {
+  heartbeat?: () => void;
+  cancellationSignal?: AbortSignal;
+};
+
+export class ExternalS3Error extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExternalS3Error";
+  }
+}

--- a/packages/server/src/worker/external-backup-s3-validation.ts
+++ b/packages/server/src/worker/external-backup-s3-validation.ts
@@ -1,0 +1,125 @@
+import type { HeadObjectCommandOutput } from "@aws-sdk/client-s3";
+import {
+  ExternalS3Error,
+  type ExternalS3Destination,
+  type ExternalS3ObjectIdentity
+} from "./external-backup-s3-types";
+
+export function validateExternalS3Destination(destination: ExternalS3Destination) {
+  if (!destination.externalImportEnabled) {
+    throw new ExternalS3Error("External backup imports are disabled for this destination.");
+  }
+  if (destination.provider !== "s3") {
+    throw new ExternalS3Error("External backup imports require an S3-compatible destination.");
+  }
+  if (destination.encryptionMode !== "none") {
+    throw new ExternalS3Error(
+      "External PostgreSQL imports require a destination without archive or rclone encryption."
+    );
+  }
+  if (!destination.bucket?.trim() || !destination.accessKey || !destination.secretAccessKey) {
+    throw new ExternalS3Error("External backup destination is missing S3 credentials or bucket.");
+  }
+  if (!destination.externalImportPrefix) {
+    throw new ExternalS3Error("External backup destination is missing an approved import prefix.");
+  }
+  const maxImportBytes = Number(destination.maxExternalImportBytes);
+  if (!Number.isSafeInteger(maxImportBytes) || maxImportBytes < 1) {
+    throw new ExternalS3Error("External backup destination has an invalid import size limit.");
+  }
+  return {
+    ...destination,
+    bucket: destination.bucket.trim(),
+    externalImportPrefix: normalizeExternalObjectPrefix(destination.externalImportPrefix),
+    maxImportBytes
+  };
+}
+
+export function normalizeExternalObjectKey(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 1024) {
+    throw new ExternalS3Error(
+      "External backup object key must contain between 1 and 1024 characters."
+    );
+  }
+  if (trimmed.startsWith("/") || trimmed.includes("\\") || hasControlCharacter(trimmed)) {
+    throw new ExternalS3Error("External backup object key contains unsupported characters.");
+  }
+  const parts = trimmed.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) {
+    throw new ExternalS3Error(
+      "External backup object key must not contain traversal path segments."
+    );
+  }
+  return parts.join("/");
+}
+
+export function resolveExternalObjectPrefix(
+  approvedPrefix: string,
+  requestedPrefix?: string
+): string {
+  if (!requestedPrefix) return approvedPrefix;
+  const requested = normalizeExternalObjectPrefix(requestedPrefix);
+  return requested.startsWith(approvedPrefix) ? requested : `${approvedPrefix}${requested}`;
+}
+
+export function assertObjectKeyWithinPrefix(key: string, approvedPrefix: string): void {
+  if (!key.startsWith(approvedPrefix)) {
+    throw new ExternalS3Error("External backup object is outside the approved import prefix.");
+  }
+}
+
+export function normalizeObjectIdentity(
+  key: string,
+  output: HeadObjectCommandOutput,
+  maxBytes: number
+): ExternalS3ObjectIdentity {
+  const size = output.ContentLength;
+  if (typeof size !== "number" || !Number.isSafeInteger(size) || size < 1 || size > maxBytes) {
+    throw new ExternalS3Error("External backup object exceeds the configured import size limit.");
+  }
+  const versionId = normalizeIdentityValue(output.VersionId);
+  const etag = normalizeEtag(output.ETag);
+  if (!versionId && !etag) {
+    throw new ExternalS3Error("External backup object is missing a version ID and ETag.");
+  }
+  return {
+    key,
+    versionId,
+    etag,
+    size,
+    contentType: normalizeMetadataValue(output.ContentType),
+    lastModified: output.LastModified ?? null
+  };
+}
+
+export function normalizeEtag(value: string | undefined): string | null {
+  return normalizeBoundedValue(value, 512);
+}
+
+function normalizeExternalObjectPrefix(value: string): string {
+  const key = normalizeExternalObjectKey(value.endsWith("/") ? value.slice(0, -1) : value);
+  return `${key}/`;
+}
+
+function normalizeIdentityValue(value: string | undefined): string | null {
+  return normalizeBoundedValue(value, 1024);
+}
+
+function normalizeMetadataValue(value: string | undefined): string | null {
+  return normalizeBoundedValue(value, 255);
+}
+
+function normalizeBoundedValue(value: string | undefined, length: number): string | null {
+  const normalized = value?.trim();
+  return normalized && normalized.length <= length && !hasControlCharacter(normalized)
+    ? normalized
+    : null;
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}

--- a/packages/server/src/worker/external-backup-s3.test.ts
+++ b/packages/server/src/worker/external-backup-s3.test.ts
@@ -144,11 +144,21 @@ describe("external S3 adapter", () => {
           });
         })
     );
-    const expectation = expect(adapter.headObject("approved/postgres/db.dump")).rejects.toThrow(
-      "External backup object could not be read."
+    const request = adapter.headObject("approved/postgres/db.dump").then(
+      () => {
+        throw new Error("Expected the metadata request to fail.");
+      },
+      (caught: unknown) => caught
     );
     await vi.advanceTimersByTimeAsync(15_000);
-    await expectation;
+    const error = await request;
+    expect(error).toBeInstanceOf(ExternalS3Error);
+    if (!(error instanceof ExternalS3Error)) throw new Error("Expected ExternalS3Error.");
+    expect(error.message).toBe("External backup object could not be read.");
+    expect(error.cause).toEqual(
+      expect.objectContaining({ message: "https://access-key:secret-key@bad-endpoint" })
+    );
+    expect(String(error)).not.toContain("secret-key");
     expect(aborted).toBe(true);
   });
 });

--- a/packages/server/src/worker/external-backup-s3.test.ts
+++ b/packages/server/src/worker/external-backup-s3.test.ts
@@ -1,0 +1,154 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createExternalS3Adapter,
+  ExternalS3Error,
+  normalizeExternalObjectKey,
+  resolveExternalObjectPrefix,
+  type ExternalS3Destination
+} from "./external-backup-s3";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  while (roots.length > 0) rmSync(roots.pop() as string, { recursive: true, force: true });
+});
+
+function destination(overrides: Partial<ExternalS3Destination> = {}): ExternalS3Destination {
+  return {
+    id: "dest_external_test",
+    provider: "s3",
+    bucket: "test-bucket",
+    region: "us-east-1",
+    endpoint: null,
+    accessKey: "access-key",
+    secretAccessKey: "secret-key",
+    encryptionMode: "none",
+    externalImportEnabled: true,
+    externalImportPrefix: "approved/postgres/",
+    maxExternalImportBytes: "2147483648",
+    ...overrides
+  };
+}
+
+function adapterWith(
+  send: (command: unknown, options?: { abortSignal?: AbortSignal }) => Promise<unknown>
+) {
+  return createExternalS3Adapter(destination(), { client: { send } as never });
+}
+
+async function* chunks(values: string[]): AsyncGenerator<Uint8Array> {
+  for (const value of values) yield Buffer.from(value);
+}
+
+describe("external S3 adapter", () => {
+  it("normalizes keys and prevents prefix escape", async () => {
+    expect(normalizeExternalObjectKey("approved/postgres/db.dump")).toBe(
+      "approved/postgres/db.dump"
+    );
+    expect(resolveExternalObjectPrefix("approved/postgres/", "nested")).toBe(
+      "approved/postgres/nested/"
+    );
+    expect(() => normalizeExternalObjectKey("approved/../secret.dump")).toThrow(ExternalS3Error);
+    await expect(
+      adapterWith(async () => ({ ContentLength: 1, ETag: '"etag"' })).headObject("outside/db.dump")
+    ).rejects.toThrow("outside the approved import prefix");
+  });
+
+  it("rejects disabled, encrypted, missing-identity, and oversized imports", async () => {
+    expect(() => createExternalS3Adapter(destination({ externalImportEnabled: false }))).toThrow(
+      "disabled"
+    );
+    expect(() => createExternalS3Adapter(destination({ encryptionMode: "rclone-crypt" }))).toThrow(
+      "without archive or rclone encryption"
+    );
+    await expect(
+      adapterWith(async () => ({ ContentLength: 1 })).headObject("approved/postgres/db.dump")
+    ).rejects.toThrow("missing a version ID and ETag");
+    await expect(
+      createExternalS3Adapter(destination({ maxExternalImportBytes: "2" }), {
+        client: { send: async () => ({ ContentLength: 3, ETag: '"etag"' }) } as never
+      }).headObject("approved/postgres/db.dump")
+    ).rejects.toThrow("exceeds the configured import size limit");
+  });
+
+  it("pins ETag downloads and verifies the streamed checksum", async () => {
+    let request: GetObjectCommand | undefined;
+    const adapter = adapterWith(async (command) => {
+      if (command instanceof GetObjectCommand) {
+        request = command;
+        return { ContentLength: 3, Body: chunks(["abc"]) };
+      }
+      throw new Error("unexpected command");
+    });
+    const root = mkdtempSync(join(tmpdir(), "daoflow-external-s3-"));
+    roots.push(root);
+    const result = await adapter.downloadPinnedObject(
+      {
+        key: "approved/postgres/db.dump",
+        versionId: null,
+        etag: '"etag-123"',
+        size: 3,
+        contentType: "application/octet-stream",
+        lastModified: null
+      },
+      join(root, "db.dump")
+    );
+
+    expect(request?.input.IfMatch).toBe('"etag-123"');
+    expect(result).toEqual({
+      bytes: 3,
+      sha256: createHash("sha256").update("abc").digest("hex")
+    });
+    expect(readFileSync(join(root, "db.dump"), "utf8")).toBe("abc");
+  });
+
+  it("aborts a streamed download, removes the partial file, and does not expose credentials", async () => {
+    const controller = new AbortController();
+    const adapter = adapterWith(async () => ({ ContentLength: 6, Body: chunks(["abc", "def"]) }));
+    const root = mkdtempSync(join(tmpdir(), "daoflow-external-s3-"));
+    roots.push(root);
+    const path = join(root, "db.dump");
+
+    await expect(
+      adapter.downloadPinnedObject(
+        {
+          key: "approved/postgres/db.dump",
+          versionId: "version-1",
+          etag: null,
+          size: 6,
+          contentType: null,
+          lastModified: null
+        },
+        path,
+        { heartbeat: () => controller.abort(), cancellationSignal: controller.signal }
+      )
+    ).rejects.toThrow("cancelled");
+    expect(() => readFileSync(path)).toThrow();
+  });
+
+  it("bounds metadata calls with an abort signal and returns a safe error", async () => {
+    vi.useFakeTimers();
+    let aborted = false;
+    const adapter = adapterWith(
+      (_command, options) =>
+        new Promise((_resolve, reject) => {
+          options?.abortSignal?.addEventListener("abort", () => {
+            aborted = true;
+            reject(new Error("https://access-key:secret-key@bad-endpoint"));
+          });
+        })
+    );
+    const expectation = expect(adapter.headObject("approved/postgres/db.dump")).rejects.toThrow(
+      "External backup object could not be read."
+    );
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expectation;
+    expect(aborted).toBe(true);
+  });
+});

--- a/packages/server/src/worker/external-backup-s3.ts
+++ b/packages/server/src/worker/external-backup-s3.ts
@@ -1,0 +1,154 @@
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+  type GetObjectCommandOutput,
+  type HeadObjectCommandOutput,
+  type ListObjectsV2CommandOutput
+} from "@aws-sdk/client-s3";
+import {
+  assertObjectKeyWithinPrefix,
+  normalizeEtag,
+  normalizeExternalObjectKey,
+  normalizeObjectIdentity,
+  resolveExternalObjectPrefix,
+  validateExternalS3Destination
+} from "./external-backup-s3-validation";
+import { sendS3Metadata, streamPinnedObjectToFile } from "./external-backup-s3-stream";
+import {
+  ExternalS3Error,
+  type ExternalS3Destination,
+  type ExternalS3ObjectIdentity,
+  type ExternalS3ObjectView,
+  type ExternalS3OperationHooks
+} from "./external-backup-s3-types";
+
+type S3Transport = {
+  send(
+    command: HeadObjectCommand,
+    options?: { abortSignal?: AbortSignal }
+  ): Promise<HeadObjectCommandOutput>;
+  send(
+    command: GetObjectCommand,
+    options?: { abortSignal?: AbortSignal }
+  ): Promise<GetObjectCommandOutput>;
+  send(
+    command: ListObjectsV2Command,
+    options?: { abortSignal?: AbortSignal }
+  ): Promise<ListObjectsV2CommandOutput>;
+};
+
+export function createExternalS3Adapter(
+  destination: ExternalS3Destination,
+  options: { client?: S3Transport } = {}
+) {
+  const config = validateExternalS3Destination(destination);
+  const client = options.client ?? createS3Client(config);
+  return {
+    listObjects: async (requestedPrefix?: string) => {
+      const prefix = resolveExternalObjectPrefix(config.externalImportPrefix, requestedPrefix);
+      const output = await sendS3Metadata(
+        (abortSignal) =>
+          client.send(
+            new ListObjectsV2Command({ Bucket: config.bucket, Prefix: prefix, MaxKeys: 1000 }),
+            { abortSignal }
+          ),
+        "External backup objects could not be listed."
+      );
+      const objects: ExternalS3ObjectView[] = (output.Contents ?? [])
+        .flatMap((object) => {
+          const { Key: key, Size: size } = object;
+          if (
+            !key ||
+            !key.startsWith(prefix) ||
+            typeof size !== "number" ||
+            !Number.isSafeInteger(size) ||
+            size < 0
+          )
+            return [];
+          return [
+            {
+              key,
+              name: key.slice(prefix.length).split("/").filter(Boolean).at(-1) ?? key,
+              size,
+              lastModified: object.LastModified?.toISOString() ?? null,
+              etag: normalizeEtag(object.ETag),
+              versionId: null
+            }
+          ];
+        })
+        .sort((left, right) => left.key.localeCompare(right.key));
+      return { prefix, objects };
+    },
+    headObject: async (requestedKey: string) => {
+      const key = normalizeExternalObjectKey(requestedKey);
+      assertObjectKeyWithinPrefix(key, config.externalImportPrefix);
+      const output = await sendS3Metadata(
+        (abortSignal) =>
+          client.send(new HeadObjectCommand({ Bucket: config.bucket, Key: key }), { abortSignal }),
+        "External backup object could not be read."
+      );
+      return normalizeObjectIdentity(key, output, config.maxImportBytes);
+    },
+    downloadPinnedObject: async (
+      object: ExternalS3ObjectIdentity,
+      destinationPath: string,
+      hooks: ExternalS3OperationHooks = {}
+    ) => {
+      assertObjectKeyWithinPrefix(object.key, config.externalImportPrefix);
+      if (!object.versionId && !object.etag) {
+        throw new ExternalS3Error("External backup object is missing a pinned version or ETag.");
+      }
+      let output: GetObjectCommandOutput;
+      try {
+        hooks.heartbeat?.();
+        output = await client.send(
+          new GetObjectCommand({
+            Bucket: config.bucket,
+            Key: object.key,
+            ...(object.versionId
+              ? { VersionId: object.versionId }
+              : { IfMatch: object.etag as string })
+          }),
+          { abortSignal: hooks.cancellationSignal }
+        );
+      } catch {
+        throw new ExternalS3Error("Pinned external backup object could not be downloaded.");
+      }
+      return streamPinnedObjectToFile({
+        body: output.Body,
+        contentLength: output.ContentLength,
+        expectedSize: object.size,
+        maxBytes: config.maxImportBytes,
+        destinationPath,
+        hooks
+      });
+    }
+  };
+}
+
+function createS3Client(
+  destination: ReturnType<typeof validateExternalS3Destination>
+): S3Transport {
+  return new S3Client({
+    region: destination.region?.trim() || "us-east-1",
+    ...(destination.endpoint?.trim()
+      ? { endpoint: destination.endpoint.trim(), forcePathStyle: true }
+      : {}),
+    credentials: {
+      accessKeyId: destination.accessKey as string,
+      secretAccessKey: destination.secretAccessKey as string
+    }
+  });
+}
+
+export {
+  ExternalS3Error,
+  normalizeExternalObjectKey,
+  resolveExternalObjectPrefix,
+  type ExternalS3Destination,
+  type ExternalS3ObjectIdentity,
+  type ExternalS3ObjectView,
+  type ExternalS3OperationHooks
+};

--- a/packages/server/src/worker/index.ts
+++ b/packages/server/src/worker/index.ts
@@ -56,10 +56,16 @@ export {
   buildBackupCronWorkflowId,
   buildOneOffBackupWorkflowId,
   buildRestoreWorkflowId,
+  buildExternalArtifactImportWorkflowId,
+  buildExternalArtifactVerificationWorkflowId,
+  buildExternalArtifactRestoreWorkflowId,
   startBackupCronWorkflow,
   cancelBackupCronWorkflow,
   startOneOffBackupWorkflow,
   startRestoreWorkflow,
+  startExternalArtifactImportWorkflow,
+  startExternalArtifactVerificationWorkflow,
+  startExternalArtifactRestoreWorkflow,
   getBackupCronStatus,
   closeTemporalClient
 } from "./temporal/client";

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-activities.test.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-activities.test.ts
@@ -1,0 +1,143 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  inspect: vi.fn(),
+  resolveImage: vi.fn(),
+  download: vi.fn()
+}));
+
+vi.mock("@temporalio/activity", () => ({
+  Context: {
+    current: () => ({ heartbeat: vi.fn(), cancellationSignal: new AbortController().signal })
+  }
+}));
+
+vi.mock("../../external-backup-s3", () => ({
+  createExternalS3Adapter: () => ({ downloadPinnedObject: mocks.download })
+}));
+
+vi.mock("./external-postgres-artifact", () => ({
+  inspectExternalPostgresCustomArchive: mocks.inspect,
+  resolveOfficialPostgresVerifierImage: mocks.resolveImage
+}));
+
+import { db } from "../../../db/connection";
+import { backupDestinations } from "../../../db/schema/destinations";
+import { externalBackupArtifacts } from "../../../db/schema/external-backup-artifacts";
+import { resetTestDatabaseWithControlPlane } from "../../../test-db";
+import { importExternalBackupArtifact } from "./external-backup-artifact-activities";
+import { externalArtifactVerificationTestHooks } from "./external-backup-artifact-verification-activity";
+
+const now = new Date("2026-07-19T00:00:00.000Z");
+const destinationId = "dest_import_retry";
+const artifactId = "xart_import_retry";
+
+async function fixture() {
+  await db.insert(backupDestinations).values({
+    id: destinationId,
+    teamId: "team_foundation",
+    name: "External destination",
+    provider: "s3",
+    bucket: "backups",
+    encryptionMode: "none",
+    externalImportEnabled: true,
+    externalImportPrefix: "approved/postgres/",
+    maxExternalImportBytes: "2147483648",
+    createdAt: now,
+    updatedAt: now
+  });
+  await db.insert(externalBackupArtifacts).values({
+    id: artifactId,
+    teamId: "team_foundation",
+    destinationId,
+    objectKey: "approved/postgres/app.dump",
+    objectVersion: null,
+    objectEtag: '"etag"',
+    sizeBytes: "3",
+    sourcePostgresVersion: "16",
+    status: "registering",
+    registeredByUserId: "user_foundation_owner",
+    createdAt: now,
+    updatedAt: now
+  });
+}
+
+describe("external artifact import workflow activity", () => {
+  beforeEach(async () => {
+    await resetTestDatabaseWithControlPlane();
+    mocks.download.mockReset();
+    mocks.download.mockResolvedValue({ sha256: "a".repeat(64), bytes: 3 });
+    mocks.resolveImage.mockReset();
+    mocks.resolveImage.mockResolvedValue(`postgres:16@sha256:${"b".repeat(64)}`);
+    mocks.inspect.mockReset();
+    mocks.inspect.mockResolvedValue({
+      sourcePostgresVersion: "16.4",
+      listingEvidence:
+        "; Format: Custom\n; Dumped from database version: 16.4\n1; 1 1 SCHEMA - public postgres"
+    });
+  });
+
+  it("records a failed import then retries the same artifact to a registered state", async () => {
+    await fixture();
+    mocks.inspect.mockRejectedValueOnce(new Error("transient archive inspector failure"));
+    await expect(
+      importExternalBackupArtifact({ artifactId, destinationUpdatedAt: now.toISOString() })
+    ).rejects.toThrow("transient archive inspector failure");
+    const [failed] = await db
+      .select()
+      .from(externalBackupArtifacts)
+      .where(eq(externalBackupArtifacts.id, artifactId));
+    expect(failed).toMatchObject({
+      status: "failed",
+      registerError: "transient archive inspector failure"
+    });
+
+    await expect(
+      importExternalBackupArtifact({ artifactId, destinationUpdatedAt: now.toISOString() })
+    ).resolves.toBeUndefined();
+    const [registered] = await db
+      .select()
+      .from(externalBackupArtifacts)
+      .where(eq(externalBackupArtifacts.id, artifactId));
+    expect(registered).toMatchObject({ status: "registered", sha256: "a".repeat(64) });
+  });
+
+  it("persists destination revision mismatch as a durable import failure", async () => {
+    await fixture();
+    await expect(
+      importExternalBackupArtifact({ artifactId, destinationUpdatedAt: "2026-07-18T00:00:00.000Z" })
+    ).rejects.toThrow("destination changed");
+    const [artifact] = await db
+      .select()
+      .from(externalBackupArtifacts)
+      .where(eq(externalBackupArtifacts.id, artifactId));
+    expect(artifact).toMatchObject({
+      status: "failed",
+      registerError: "External import destination changed after object validation."
+    });
+  });
+
+  it("records workspace cleanup success and failure accurately in verification evidence", () => {
+    const verification = {
+      success: true,
+      cleanup: { workspaceRemoved: false, attempted: true, containerRemoved: true }
+    } as never;
+    externalArtifactVerificationTestHooks.applyWorkspaceCleanupResult(verification, null);
+    expect(verification).toMatchObject({ success: true, cleanup: { workspaceRemoved: true } });
+
+    const failed = {
+      success: true,
+      cleanup: { workspaceRemoved: false, attempted: true, containerRemoved: true }
+    } as never;
+    externalArtifactVerificationTestHooks.applyWorkspaceCleanupResult(
+      failed,
+      "workspace cleanup failed"
+    );
+    expect(failed).toMatchObject({
+      success: false,
+      error: "workspace cleanup failed",
+      cleanup: { workspaceRemoved: false, error: "workspace cleanup failed" }
+    });
+  });
+});

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-activities.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-activities.ts
@@ -1,0 +1,3 @@
+export { importExternalBackupArtifact } from "./external-backup-artifact-import-activity";
+export { verifyExternalBackupArtifact } from "./external-backup-artifact-verification-activity";
+export { executeExternalArtifactRestore } from "./external-backup-artifact-restore-activity";

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-activity-shared.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-activity-shared.ts
@@ -1,0 +1,56 @@
+import { Context } from "@temporalio/activity";
+import { and, eq } from "drizzle-orm";
+import { join } from "node:path";
+import { db } from "../../../db/connection";
+import { backupDestinations } from "../../../db/schema/destinations";
+import { externalBackupArtifacts } from "../../../db/schema/external-backup-artifacts";
+import { createExternalS3Adapter } from "../../external-backup-s3";
+import { toExternalArtifactS3Destination } from "./external-backup-artifact-runtime";
+
+export type ExternalArtifactContext = {
+  artifact: typeof externalBackupArtifacts.$inferSelect;
+  destination: typeof backupDestinations.$inferSelect;
+};
+
+export async function loadExternalArtifactContext(
+  artifactId: string
+): Promise<ExternalArtifactContext | null> {
+  const [row] = await db
+    .select({ artifact: externalBackupArtifacts, destination: backupDestinations })
+    .from(externalBackupArtifacts)
+    .innerJoin(backupDestinations, eq(backupDestinations.id, externalBackupArtifacts.destinationId))
+    .where(
+      and(
+        eq(externalBackupArtifacts.id, artifactId),
+        eq(externalBackupArtifacts.teamId, backupDestinations.teamId)
+      )
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export async function downloadExternalArtifact(context: ExternalArtifactContext, workDir: string) {
+  const adapter = createExternalS3Adapter(toExternalArtifactS3Destination(context.destination));
+  const path = join(workDir, "artifact.dump");
+  const result = await adapter.downloadPinnedObject(
+    {
+      key: context.artifact.objectKey,
+      versionId: context.artifact.objectVersion,
+      etag: context.artifact.objectEtag,
+      size: Number(context.artifact.sizeBytes),
+      contentType: context.artifact.contentType,
+      lastModified: context.artifact.lastModified
+    },
+    path,
+    temporalExternalArtifactHooks()
+  );
+  return { path, ...result };
+}
+
+export function temporalExternalArtifactHooks() {
+  const context = Context.current();
+  return {
+    heartbeat: () => context.heartbeat(),
+    cancellationSignal: context.cancellationSignal
+  };
+}

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-import-activity.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-import-activity.ts
@@ -1,0 +1,118 @@
+import { eq } from "drizzle-orm";
+import { db } from "../../../db/connection";
+import { externalBackupArtifacts } from "../../../db/schema/external-backup-artifacts";
+import { writeExternalBackupArtifactAudit } from "../../../db/services/external-backup-artifact-audit";
+import type { ExternalArtifactImportWorkflowInput } from "../external-artifact-workflow-input";
+import {
+  downloadExternalArtifact,
+  loadExternalArtifactContext,
+  temporalExternalArtifactHooks
+} from "./external-backup-artifact-activity-shared";
+import {
+  createExternalArtifactWorkspace,
+  removeExternalArtifactWorkspace,
+  safeExternalArtifactError
+} from "./external-backup-artifact-runtime";
+import {
+  inspectExternalPostgresCustomArchive,
+  resolveOfficialPostgresVerifierImage
+} from "./external-postgres-artifact";
+
+export async function importExternalBackupArtifact(
+  input: ExternalArtifactImportWorkflowInput
+): Promise<void> {
+  const context = await loadExternalArtifactContext(input.artifactId);
+  if (!context || !["registering", "failed"].includes(context.artifact.status)) return;
+
+  const workDir = createExternalArtifactWorkspace(input.artifactId);
+  let registered = false;
+  let operationError: Error | null = null;
+  try {
+    if (context.destination.updatedAt.toISOString() !== input.destinationUpdatedAt) {
+      throw new Error("External import destination changed after object validation.");
+    }
+    if (context.artifact.status === "failed") {
+      await db
+        .update(externalBackupArtifacts)
+        .set({ status: "registering", registerError: null, updatedAt: new Date() })
+        .where(eq(externalBackupArtifacts.id, context.artifact.id));
+    }
+    const downloaded = await downloadExternalArtifact(context, workDir);
+    const verifierImage = await resolveOfficialPostgresVerifierImage(
+      context.artifact.sourcePostgresVersion,
+      temporalExternalArtifactHooks()
+    );
+    const inspected = await inspectExternalPostgresCustomArchive({
+      artifactId: context.artifact.id,
+      dumpPath: downloaded.path,
+      checksum: downloaded.sha256,
+      expectedPostgresMajor: context.artifact.sourcePostgresVersion,
+      verifierImage,
+      verifierHooks: temporalExternalArtifactHooks()
+    });
+    const now = new Date();
+    await db
+      .update(externalBackupArtifacts)
+      .set({
+        sizeBytes: String(downloaded.bytes),
+        sha256: downloaded.sha256,
+        sourcePostgresVersion: inspected.sourcePostgresVersion,
+        verifierImage,
+        listingEvidence: inspected.listingEvidence,
+        status: "registered",
+        registerError: null,
+        registeredAt: now,
+        updatedAt: now
+      })
+      .where(eq(externalBackupArtifacts.id, context.artifact.id));
+    registered = true;
+    await writeExternalBackupArtifactAudit({
+      teamId: context.artifact.teamId,
+      destinationId: context.artifact.destinationId,
+      artifactId: context.artifact.id,
+      objectKey: context.artifact.objectKey,
+      action: "external-artifact.import.succeeded",
+      permissionScope: "backup:restore",
+      outcome: "success",
+      detail: "Registered external PostgreSQL backup artifact after isolated archive inspection."
+    });
+  } catch (error) {
+    const message = safeExternalArtifactError(error);
+    await db
+      .update(externalBackupArtifacts)
+      .set({ status: "failed", registerError: message, updatedAt: new Date() })
+      .where(eq(externalBackupArtifacts.id, input.artifactId));
+    await writeExternalBackupArtifactAudit({
+      teamId: context.artifact.teamId,
+      destinationId: context.artifact.destinationId,
+      artifactId: context.artifact.id,
+      objectKey: context.artifact.objectKey,
+      action: "external-artifact.import.failed",
+      permissionScope: "backup:restore",
+      outcome: "failure",
+      detail: "External PostgreSQL backup artifact registration failed."
+    });
+    operationError = new Error(message);
+  }
+
+  const cleanupError = removeExternalArtifactWorkspace(workDir);
+  if (cleanupError) {
+    await db
+      .update(externalBackupArtifacts)
+      .set({ status: "failed", registerError: cleanupError, updatedAt: new Date() })
+      .where(eq(externalBackupArtifacts.id, context.artifact.id));
+    await writeExternalBackupArtifactAudit({
+      teamId: context.artifact.teamId,
+      destinationId: context.artifact.destinationId,
+      artifactId: context.artifact.id,
+      objectKey: context.artifact.objectKey,
+      action: "external-artifact.import.cleanup-failed",
+      permissionScope: "backup:restore",
+      outcome: "failure",
+      detail: "External artifact registration temporary workspace cleanup failed."
+    });
+    if (registered) operationError = new Error(cleanupError);
+  }
+
+  if (operationError) throw operationError;
+}

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-restore-activity.test.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-restore-activity.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  audit: vi.fn(),
+  dbSelect: vi.fn(),
+  dbUpdate: vi.fn(),
+  download: vi.fn(),
+  executeDatabaseRestore: vi.fn(),
+  loadContext: vi.fn(),
+  removeWorkspace: vi.fn(),
+  resolveMemberRole: vi.fn(),
+  resolveMetadata: vi.fn(),
+  resolveRuntime: vi.fn(),
+  resolveVolumeTeam: vi.fn(),
+  updatedValues: [] as Record<string, unknown>[],
+  withPreparedTarget: vi.fn()
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn((...values: unknown[]) => values),
+  eq: vi.fn((...values: unknown[]) => values)
+}));
+
+vi.mock("../../../db/connection", () => ({
+  db: { select: mocks.dbSelect, update: mocks.dbUpdate }
+}));
+
+vi.mock("../../../db/schema/audit", () => ({ approvalRequests: {} }));
+vi.mock("../../../db/schema/storage", () => ({ backupRestores: {}, volumes: {} }));
+vi.mock("../../../db/services/backup-resource-team", () => ({
+  resolveVolumeTeamId: mocks.resolveVolumeTeam
+}));
+vi.mock("../../../db/services/external-backup-artifact-audit", () => ({
+  writeExternalBackupArtifactAudit: mocks.audit
+}));
+vi.mock("../../../db/services/external-backup-artifact-read", () => ({
+  resolveExternalPostgresRestoreRuntime: mocks.resolveRuntime,
+  resolveExternalPostgresTargetMetadata: mocks.resolveMetadata
+}));
+vi.mock("../../../db/services/teams", () => ({
+  resolveMemberRoleForTeam: mocks.resolveMemberRole
+}));
+vi.mock("../../execution-target", () => ({
+  withPreparedExecutionTarget: mocks.withPreparedTarget
+}));
+vi.mock("./external-backup-artifact-activity-shared", () => ({
+  downloadExternalArtifact: mocks.download,
+  loadExternalArtifactContext: mocks.loadContext,
+  temporalExternalArtifactHooks: () => ({})
+}));
+vi.mock("./external-backup-artifact-runtime", () => ({
+  createExternalArtifactWorkspace: () => "/tmp/external-restore",
+  removeExternalArtifactWorkspace: mocks.removeWorkspace,
+  safeExternalArtifactError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error)
+}));
+vi.mock("./restore-database", () => ({ executeDatabaseRestore: mocks.executeDatabaseRestore }));
+
+import { executeExternalArtifactRestore } from "./external-backup-artifact-restore-activity";
+
+const updatedAt = new Date("2026-07-19T00:00:00.000Z");
+const metadata = {
+  databaseName: "app",
+  databaseUser: "app_user",
+  runtimeServiceName: "postgres",
+  targetServiceId: "svc_postgres",
+  targetServiceUpdatedAt: updatedAt.toISOString(),
+  runtimeBinding: { kind: "service" as const, serviceId: "svc_postgres" }
+};
+const volume = {
+  id: "vol_postgres",
+  name: "postgres-data",
+  serverId: "srv_production",
+  mountPath: "/var/lib/postgresql/data",
+  metadata: { databasePassword: "not-logged" },
+  updatedAt
+};
+const context = {
+  artifact: {
+    id: "xart_postgres",
+    teamId: "team_foundation",
+    destinationId: "dest_external",
+    objectKey: "approved/postgres/app.dump",
+    objectVersion: "version-1",
+    objectEtag: "etag-1",
+    sha256: "a".repeat(64),
+    status: "verified",
+    verifiedAt: updatedAt
+  },
+  destination: { id: "dest_external", updatedAt }
+};
+
+function rows(values: unknown[]) {
+  return { from: () => ({ where: () => ({ limit: () => Promise.resolve(values) }) }) };
+}
+
+describe("external artifact production restore finalization", () => {
+  beforeEach(() => {
+    mocks.audit.mockReset();
+    mocks.dbSelect.mockReset();
+    mocks.dbUpdate.mockReset();
+    mocks.download.mockReset();
+    mocks.executeDatabaseRestore.mockReset();
+    mocks.loadContext.mockReset();
+    mocks.removeWorkspace.mockReset();
+    mocks.resolveMemberRole.mockReset();
+    mocks.resolveMetadata.mockReset();
+    mocks.resolveRuntime.mockReset();
+    mocks.resolveVolumeTeam.mockReset();
+    mocks.updatedValues.splice(0);
+    mocks.withPreparedTarget.mockReset();
+    mocks.dbUpdate.mockImplementation(() => ({
+      set: (values: Record<string, unknown>) => {
+        mocks.updatedValues.push(values);
+        return { where: () => Promise.resolve() };
+      }
+    }));
+    mocks.dbSelect
+      .mockImplementationOnce(() => rows([volume]))
+      .mockImplementationOnce(() => rows([{ resolvedByUserId: "user_owner" }]))
+      .mockImplementationOnce(() => rows([{ resolvedByUserId: "user_owner" }]));
+    mocks.loadContext.mockResolvedValue(context);
+    mocks.resolveVolumeTeam.mockResolvedValue("team_foundation");
+    mocks.resolveMemberRole.mockResolvedValue("owner");
+    mocks.resolveMetadata.mockResolvedValue(metadata);
+    mocks.download.mockResolvedValue({
+      path: "/tmp/external-restore/app.dump",
+      sha256: "a".repeat(64)
+    });
+    mocks.resolveRuntime.mockResolvedValue({
+      ...metadata,
+      target: { mode: "local" },
+      runtime: { kind: "container", containerName: "project-postgres-1" }
+    });
+    mocks.withPreparedTarget.mockImplementation(
+      async (target: unknown, run: (prepared: unknown) => Promise<unknown>) => run(target)
+    );
+    mocks.executeDatabaseRestore.mockResolvedValue({ success: true, bytesRestored: 3 });
+    mocks.removeWorkspace.mockReturnValue("Temporary artifact workspace could not be removed.");
+    mocks.audit.mockRejectedValue(new Error("audit storage unavailable"));
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  it("keeps a completed restore successful when audit and cleanup reporting fail", async () => {
+    const approval = {
+      approvalRequestId: "apr_restore",
+      expectedTeamId: "team_foundation",
+      snapshot: {
+        artifactId: context.artifact.id,
+        artifactSha256: context.artifact.sha256,
+        artifactObjectKey: context.artifact.objectKey,
+        artifactObjectVersion: context.artifact.objectVersion,
+        artifactObjectEtag: context.artifact.objectEtag,
+        artifactVerifiedAt: updatedAt.toISOString(),
+        destinationId: context.destination.id,
+        destinationUpdatedAt: updatedAt.toISOString(),
+        targetVolumeId: volume.id,
+        targetVolumeUpdatedAt: updatedAt.toISOString(),
+        targetServerId: volume.serverId,
+        targetMountPath: volume.mountPath,
+        targetServiceId: metadata.targetServiceId,
+        targetServiceUpdatedAt: metadata.targetServiceUpdatedAt,
+        runtimeServiceName: metadata.runtimeServiceName,
+        databaseEngine: "postgres" as const,
+        databaseName: metadata.databaseName,
+        databaseUser: metadata.databaseUser,
+        secretPolicy: "destination-credentials-encrypted" as const
+      }
+    };
+
+    await expect(
+      executeExternalArtifactRestore({
+        artifactId: context.artifact.id,
+        restoreId: "brest_postgres",
+        targetVolumeId: volume.id,
+        approval
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mocks.executeDatabaseRestore).toHaveBeenCalledTimes(1);
+    expect(mocks.executeDatabaseRestore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionTarget: { mode: "local" },
+        runtime: { kind: "container", containerName: "project-postgres-1" }
+      }),
+      "/tmp/external-restore/app.dump",
+      {}
+    );
+    expect(mocks.updatedValues.map((value) => value.status)).toEqual(["running", "succeeded"]);
+    expect(mocks.removeWorkspace).toHaveBeenCalledTimes(1);
+    expect(mocks.audit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "external-artifact.restore.cleanup-failed",
+        outcome: "failure"
+      })
+    );
+  });
+});

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-restore-activity.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-restore-activity.ts
@@ -1,0 +1,241 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "../../../db/connection";
+import { approvalRequests } from "../../../db/schema/audit";
+import { backupRestores, volumes } from "../../../db/schema/storage";
+import { resolveVolumeTeamId } from "../../../db/services/backup-resource-team";
+import {
+  resolveExternalPostgresRestoreRuntime,
+  resolveExternalPostgresTargetMetadata
+} from "../../../db/services/external-backup-artifact-read";
+import { asRecord, readString } from "../../../db/services/json-helpers";
+import { resolveMemberRoleForTeam } from "../../../db/services/teams";
+import { writeExternalBackupArtifactAudit } from "../../../db/services/external-backup-artifact-audit";
+import type {
+  ExternalArtifactRestoreApproval,
+  ExternalArtifactRestoreWorkflowInput
+} from "../external-artifact-workflow-input";
+import {
+  downloadExternalArtifact,
+  loadExternalArtifactContext,
+  temporalExternalArtifactHooks,
+  type ExternalArtifactContext
+} from "./external-backup-artifact-activity-shared";
+import {
+  createExternalArtifactWorkspace,
+  removeExternalArtifactWorkspace,
+  safeExternalArtifactError
+} from "./external-backup-artifact-runtime";
+import { executeDatabaseRestore } from "./restore-database";
+import { withPreparedExecutionTarget } from "../../execution-target";
+
+export async function executeExternalArtifactRestore(
+  input: ExternalArtifactRestoreWorkflowInput
+): Promise<void> {
+  const context = await loadExternalArtifactContext(input.artifactId);
+  const [volume] = await db
+    .select()
+    .from(volumes)
+    .where(eq(volumes.id, input.targetVolumeId))
+    .limit(1);
+  if (!context || !volume) {
+    await markExternalRestoreFailed(
+      input.restoreId,
+      "External restore target is no longer available."
+    );
+    return;
+  }
+
+  const workDir = createExternalArtifactWorkspace(input.restoreId);
+  let restoredSuccessfully = false;
+  let operationError: Error | null = null;
+  try {
+    try {
+      await revalidateExternalRestoreApproval(context, volume, input.approval);
+      if (context.artifact.status !== "verified" || !context.artifact.sha256) {
+        throw new Error("External artifact is no longer verified for production restore.");
+      }
+      await markExternalRestoreRunning(input.restoreId);
+      const downloaded = await downloadExternalArtifact(context, workDir);
+      if (downloaded.sha256 !== context.artifact.sha256) {
+        throw new Error(
+          "Pinned external backup object checksum no longer matches its registration."
+        );
+      }
+      await revalidateExternalRestoreApproval(context, volume, input.approval);
+      const runtime = await resolveExternalPostgresRestoreRuntime({
+        volume,
+        teamId: context.artifact.teamId,
+        restoreId: input.restoreId
+      });
+      if (!runtime) {
+        throw new Error(
+          "Selected PostgreSQL target is no longer available on its approved server."
+        );
+      }
+      const restored = await withPreparedExecutionTarget(runtime.target, (target) =>
+        executeDatabaseRestore(
+          {
+            databaseEngine: "postgres",
+            databasePassword:
+              readString(asRecord(volume.metadata), "databasePassword") || undefined,
+            databaseUser: runtime.databaseUser,
+            databaseName: runtime.databaseName,
+            volumeName: volume.name,
+            executionTarget: target,
+            runtime: runtime.runtime
+          },
+          downloaded.path,
+          temporalExternalArtifactHooks()
+        )
+      );
+      if (!restored.success) throw new Error(restored.error ?? "External database restore failed.");
+      await db
+        .update(backupRestores)
+        .set({ status: "succeeded", error: null, completedAt: new Date() })
+        .where(eq(backupRestores.id, input.restoreId));
+      restoredSuccessfully = true;
+      await writeExternalRestoreAudit({
+        teamId: context.artifact.teamId,
+        destinationId: context.artifact.destinationId,
+        artifactId: context.artifact.id,
+        objectKey: context.artifact.objectKey,
+        action: "external-artifact.restore.succeeded",
+        permissionScope: "backup:restore",
+        outcome: "success",
+        detail:
+          "Approved external PostgreSQL backup artifact was restored to its selected target volume."
+      });
+    } catch (error) {
+      const message = safeExternalArtifactError(error);
+      await markExternalRestoreFailed(input.restoreId, message);
+      await writeExternalRestoreAudit({
+        teamId: context.artifact.teamId,
+        destinationId: context.artifact.destinationId,
+        artifactId: context.artifact.id,
+        objectKey: context.artifact.objectKey,
+        action: "external-artifact.restore.failed",
+        permissionScope: "backup:restore",
+        outcome: "failure",
+        detail: "Approved external PostgreSQL backup artifact restore failed."
+      });
+      operationError = new Error(message);
+    }
+  } finally {
+    let cleanupError: string | null;
+    try {
+      cleanupError = removeExternalArtifactWorkspace(workDir);
+    } catch (error) {
+      cleanupError = safeExternalArtifactError(error);
+    }
+    if (cleanupError) {
+      await writeExternalRestoreAudit({
+        teamId: context.artifact.teamId,
+        destinationId: context.artifact.destinationId,
+        artifactId: context.artifact.id,
+        objectKey: context.artifact.objectKey,
+        action: "external-artifact.restore.cleanup-failed",
+        permissionScope: "backup:restore",
+        outcome: "failure",
+        detail: restoredSuccessfully
+          ? "External artifact restore succeeded, but temporary workspace cleanup failed."
+          : "External artifact restore temporary workspace cleanup failed."
+      });
+    }
+  }
+
+  if (operationError) throw operationError;
+}
+
+async function writeExternalRestoreAudit(
+  input: Parameters<typeof writeExternalBackupArtifactAudit>[0]
+): Promise<void> {
+  try {
+    await writeExternalBackupArtifactAudit(input);
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        event: "external-artifact.restore.audit-write-failed",
+        action: input.action,
+        error: safeExternalArtifactError(error)
+      })
+    );
+  }
+}
+
+async function revalidateExternalRestoreApproval(
+  context: ExternalArtifactContext,
+  volume: typeof volumes.$inferSelect,
+  approval: ExternalArtifactRestoreApproval
+): Promise<void> {
+  const [request] = await db
+    .select({ resolvedByUserId: approvalRequests.resolvedByUserId })
+    .from(approvalRequests)
+    .where(
+      and(
+        eq(approvalRequests.id, approval.approvalRequestId),
+        eq(approvalRequests.teamId, approval.expectedTeamId),
+        eq(approvalRequests.actionType, "external-artifact-restore"),
+        eq(approvalRequests.targetResource, `external-backup-artifact/${context.artifact.id}`),
+        eq(approvalRequests.status, "approved")
+      )
+    )
+    .limit(1);
+  if (!request?.resolvedByUserId) throw new Error("External restore approval is no longer valid.");
+  const role = await resolveMemberRoleForTeam(request.resolvedByUserId, approval.expectedTeamId);
+  if (role !== "owner" && role !== "admin") {
+    throw new Error("The approving actor no longer has decision authority for this team.");
+  }
+  if ((await resolveVolumeTeamId(volume)) !== approval.expectedTeamId) {
+    throw new Error("External restore target no longer belongs to the approved team.");
+  }
+  const target = await requirePostgresTargetMetadata(volume, approval.expectedTeamId);
+  const snapshot = approval.snapshot;
+  const matches =
+    context.artifact.teamId === approval.expectedTeamId &&
+    context.artifact.status === "verified" &&
+    snapshot.secretPolicy === "destination-credentials-encrypted" &&
+    snapshot.artifactId === context.artifact.id &&
+    snapshot.artifactSha256 === context.artifact.sha256 &&
+    snapshot.artifactObjectKey === context.artifact.objectKey &&
+    snapshot.artifactObjectVersion === (context.artifact.objectVersion ?? "") &&
+    snapshot.artifactObjectEtag === (context.artifact.objectEtag ?? "") &&
+    snapshot.artifactVerifiedAt === (context.artifact.verifiedAt?.toISOString() ?? "") &&
+    snapshot.destinationId === context.destination.id &&
+    snapshot.destinationUpdatedAt === context.destination.updatedAt.toISOString() &&
+    snapshot.targetVolumeId === volume.id &&
+    snapshot.targetVolumeUpdatedAt === volume.updatedAt.toISOString() &&
+    snapshot.targetServerId === volume.serverId &&
+    snapshot.targetMountPath === volume.mountPath &&
+    snapshot.targetServiceId === target.targetServiceId &&
+    snapshot.targetServiceUpdatedAt === target.targetServiceUpdatedAt &&
+    snapshot.runtimeServiceName === target.runtimeServiceName &&
+    snapshot.databaseEngine === "postgres" &&
+    snapshot.databaseName === target.databaseName &&
+    snapshot.databaseUser === target.databaseUser;
+  if (!matches) {
+    throw new Error(
+      "External restore approval no longer matches its immutable artifact and target snapshot."
+    );
+  }
+}
+
+async function requirePostgresTargetMetadata(volume: typeof volumes.$inferSelect, teamId: string) {
+  const metadata = await resolveExternalPostgresTargetMetadata(volume, teamId);
+  if (!metadata)
+    throw new Error("Selected target volume is missing required PostgreSQL database metadata.");
+  return metadata;
+}
+
+async function markExternalRestoreRunning(restoreId: string) {
+  await db
+    .update(backupRestores)
+    .set({ status: "running", error: null, startedAt: new Date(), completedAt: null })
+    .where(eq(backupRestores.id, restoreId));
+}
+
+async function markExternalRestoreFailed(restoreId: string, error: string) {
+  await db
+    .update(backupRestores)
+    .set({ status: "failed", error, completedAt: new Date() })
+    .where(eq(backupRestores.id, restoreId));
+}

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-runtime.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-runtime.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { toDestinationConfig } from "../../../db/services/destination-shared";
+import { backupDestinations } from "../../../db/schema/destinations";
+import type { ExternalS3Destination } from "../../external-backup-s3";
+
+export function createExternalArtifactWorkspace(id: string): string {
+  return mkdtempSync(join(tmpdir(), `daoflow-external-${id}-`));
+}
+
+export function removeExternalArtifactWorkspace(path: string): string | null {
+  try {
+    rmSync(path, { recursive: true, force: true });
+    return null;
+  } catch {
+    return "Temporary artifact workspace could not be removed.";
+  }
+}
+
+export function toExternalArtifactS3Destination(
+  destination: typeof backupDestinations.$inferSelect
+): ExternalS3Destination {
+  const config = toDestinationConfig(destination);
+  return {
+    id: destination.id,
+    provider: config.provider,
+    bucket: config.bucket ?? null,
+    region: config.region ?? null,
+    endpoint: config.endpoint ?? null,
+    accessKey: config.accessKey ?? null,
+    secretAccessKey: config.secretAccessKey ?? null,
+    encryptionMode: config.encryptionMode ?? "none",
+    externalImportEnabled: destination.externalImportEnabled,
+    externalImportPrefix: destination.externalImportPrefix,
+    maxExternalImportBytes: destination.maxExternalImportBytes
+  };
+}
+
+export function safeExternalArtifactError(error: unknown): string {
+  const message =
+    error instanceof Error ? error.message : "External backup artifact operation failed.";
+  return message
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/@]+(?::[^\s/@]+)?@/gi, "$1[redacted]@")
+    .replace(
+      /\b(password|passwd|secret|token|api[_-]?key|credential)\s*([=:])\s*[^\s,;]+/gi,
+      "$1$2[redacted]"
+    )
+    .slice(0, 500);
+}

--- a/packages/server/src/worker/temporal/activities/external-backup-artifact-verification-activity.ts
+++ b/packages/server/src/worker/temporal/activities/external-backup-artifact-verification-activity.ts
@@ -1,0 +1,177 @@
+import { eq } from "drizzle-orm";
+import { db } from "../../../db/connection";
+import { externalBackupArtifacts } from "../../../db/schema/external-backup-artifacts";
+import { backupRestores, type BackupVerificationResult } from "../../../db/schema/storage";
+import { writeExternalBackupArtifactAudit } from "../../../db/services/external-backup-artifact-audit";
+import type { ExternalArtifactVerificationWorkflowInput } from "../external-artifact-workflow-input";
+import {
+  downloadExternalArtifact,
+  loadExternalArtifactContext,
+  temporalExternalArtifactHooks,
+  type ExternalArtifactContext
+} from "./external-backup-artifact-activity-shared";
+import {
+  createExternalArtifactWorkspace,
+  removeExternalArtifactWorkspace,
+  safeExternalArtifactError
+} from "./external-backup-artifact-runtime";
+import { verifyPostgresRestore } from "./postgres-restore-verification";
+
+export async function verifyExternalBackupArtifact(
+  input: ExternalArtifactVerificationWorkflowInput
+): Promise<void> {
+  const context = await loadExternalArtifactContext(input.artifactId);
+  if (!context || !context.artifact.sha256 || !context.artifact.verifierImage) {
+    await markExternalRestoreFailed(
+      input.restoreId,
+      "External artifact is not eligible for verification."
+    );
+    return;
+  }
+
+  const workDir = createExternalArtifactWorkspace(input.restoreId);
+  let verification: BackupVerificationResult;
+  try {
+    await db
+      .update(externalBackupArtifacts)
+      .set({ status: "verifying", updatedAt: new Date() })
+      .where(eq(externalBackupArtifacts.id, context.artifact.id));
+    await markExternalRestoreRunning(input.restoreId);
+    const downloaded = await downloadExternalArtifact(context, workDir);
+    if (downloaded.sha256 !== context.artifact.sha256) {
+      throw new Error("Pinned external backup object checksum no longer matches its registration.");
+    }
+    const result = await verifyPostgresRestore(
+      {
+        restoreId: input.restoreId,
+        localDumpPath: downloaded.path,
+        expectedSha256: context.artifact.sha256,
+        sourcePostgresVersion: context.artifact.sourcePostgresVersion,
+        verifierImage: context.artifact.verifierImage
+      },
+      temporalExternalArtifactHooks()
+    );
+    verification = toVerificationResult(result);
+  } catch (error) {
+    verification = rejectedExternalVerification(context, safeExternalArtifactError(error));
+  }
+
+  applyWorkspaceCleanupResult(verification, removeExternalArtifactWorkspace(workDir));
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    await tx
+      .update(backupRestores)
+      .set({
+        status: verification.success ? "succeeded" : "failed",
+        verificationResult: verification,
+        error: verification.error ?? null,
+        completedAt: now
+      })
+      .where(eq(backupRestores.id, input.restoreId));
+    await tx
+      .update(externalBackupArtifacts)
+      .set({
+        status: verification.success ? "verified" : "registered",
+        verifiedAt: verification.success ? now : context.artifact.verifiedAt,
+        latestVerification: verification,
+        registerError: verification.success ? null : (verification.error ?? "Verification failed."),
+        updatedAt: now
+      })
+      .where(eq(externalBackupArtifacts.id, context.artifact.id));
+  });
+  await writeExternalBackupArtifactAudit({
+    teamId: context.artifact.teamId,
+    destinationId: context.artifact.destinationId,
+    artifactId: context.artifact.id,
+    objectKey: context.artifact.objectKey,
+    action: verification.success
+      ? "external-artifact.verify.succeeded"
+      : "external-artifact.verify.failed",
+    permissionScope: "backup:restore",
+    outcome: verification.success ? "success" : "failure",
+    detail: verification.success
+      ? "External backup artifact passed an isolated PostgreSQL restore verification."
+      : "External backup artifact failed an isolated PostgreSQL restore verification."
+  });
+}
+
+function toVerificationResult(
+  result: Awaited<ReturnType<typeof verifyPostgresRestore>>
+): BackupVerificationResult {
+  return {
+    version: 1,
+    success: result.success,
+    checksum: result.checksum,
+    sourceEngineVersion: result.sourcePostgresVersion,
+    verifierEngineVersion: result.verifierPostgresVersion,
+    durationMs: result.durationMs,
+    checks: result.checks,
+    objectCounts: result.objectCounts,
+    cleanup: {
+      attempted: result.cleanup.attempted,
+      containerRemoved: result.cleanup.containerRemoved,
+      workspaceRemoved: false,
+      ...(result.cleanup.error ? { error: result.cleanup.error } : {})
+    },
+    completedAt: result.completedAt,
+    ...(result.error ? { error: result.error } : {})
+  };
+}
+
+function rejectedExternalVerification(
+  context: ExternalArtifactContext,
+  error: string
+): BackupVerificationResult {
+  const skipped = { status: "skipped" as const, detail: "Not run." };
+  return {
+    version: 1,
+    success: false,
+    checksum: context.artifact.sha256 ?? "",
+    sourceEngineVersion: context.artifact.sourcePostgresVersion,
+    verifierEngineVersion: context.artifact.verifierImage ?? "unknown",
+    durationMs: 0,
+    checks: {
+      input: { status: "failed", detail: error },
+      checksum: skipped,
+      verifierImage: skipped,
+      archive: skipped,
+      container: skipped,
+      readiness: skipped,
+      restore: skipped,
+      catalog: skipped
+    },
+    objectCounts: { schemas: 0, tables: 0, indexes: 0, functions: 0 },
+    cleanup: { attempted: false, containerRemoved: false, workspaceRemoved: false },
+    completedAt: new Date().toISOString(),
+    error
+  };
+}
+
+function applyWorkspaceCleanupResult(
+  verification: BackupVerificationResult,
+  cleanupError: string | null
+) {
+  verification.cleanup.workspaceRemoved = !cleanupError;
+  if (!cleanupError) return;
+  verification.success = false;
+  verification.cleanup.error = verification.cleanup.error
+    ? `${verification.cleanup.error} ${cleanupError}`
+    : cleanupError;
+  verification.error = verification.error ? `${verification.error} ${cleanupError}` : cleanupError;
+}
+
+async function markExternalRestoreRunning(restoreId: string) {
+  await db
+    .update(backupRestores)
+    .set({ status: "running", error: null, startedAt: new Date(), completedAt: null })
+    .where(eq(backupRestores.id, restoreId));
+}
+
+async function markExternalRestoreFailed(restoreId: string, error: string) {
+  await db
+    .update(backupRestores)
+    .set({ status: "failed", error, completedAt: new Date() })
+    .where(eq(backupRestores.id, restoreId));
+}
+
+export const externalArtifactVerificationTestHooks = { applyWorkspaceCleanupResult };

--- a/packages/server/src/worker/temporal/activities/external-postgres-artifact.test.ts
+++ b/packages/server/src/worker/temporal/activities/external-postgres-artifact.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseExternalPostgresArchiveListing,
+  resolveOfficialPostgresVerifierImage
+} from "./external-postgres-artifact";
+
+const safeListing = `;
+; Archive created at 2026-07-19 00:00:00 UTC
+;     dbname: app
+;     TOC Entries: 3
+;     Format: Custom
+;     Dumped from database version: 16.4
+;     Dumped by pg_dump version: 16.4
+;
+1; 2615 2200 SCHEMA - public postgres
+2; 1259 16384 TABLE public widgets postgres
+3; 0 16384 TABLE DATA public widgets postgres
+`;
+
+describe("external PostgreSQL archive inspection", () => {
+  it("persists sanitized listing evidence and validates the expected source major", () => {
+    const parsed = parseExternalPostgresArchiveListing(safeListing, "16");
+    expect(parsed.sourcePostgresVersion).toBe("16.4");
+    expect(parsed.listingEvidence).toContain("Format: Custom");
+    expect(parsed.listingEvidence).toContain("TABLE DATA");
+  });
+
+  it("accepts the vendor suffix and uppercase format emitted by official PostgreSQL images", () => {
+    const officialListing = safeListing
+      .replace("Format: Custom", "Format: CUSTOM")
+      .replace(
+        "Dumped from database version: 16.4",
+        "Dumped from database version: 16.4 (Debian 16.4-1.pgdg120+1)"
+      );
+
+    expect(parseExternalPostgresArchiveListing(officialListing, "16").sourcePostgresVersion).toBe(
+      "16.4"
+    );
+  });
+
+  it("rejects invalid custom listings, mismatched majors, and unsafe archive entries", () => {
+    expect(() =>
+      parseExternalPostgresArchiveListing(safeListing.replace("Custom", "Tar"), "16")
+    ).toThrow("not a PostgreSQL custom-format archive");
+    expect(() => parseExternalPostgresArchiveListing(safeListing, "15")).toThrow("does not match");
+    expect(() =>
+      parseExternalPostgresArchiveListing(
+        `${safeListing}4; 0 0 DATABASE - dangerous postgres\n`,
+        "16"
+      )
+    ).toThrow("unsupported archive entry type: DATABASE");
+  });
+
+  it("resolves an immutable official image through a heartbeating cancellable runner", async () => {
+    const calls: string[][] = [];
+    let heartbeats = 0;
+    const image = await resolveOfficialPostgresVerifierImage("16", {
+      heartbeat: () => heartbeats++,
+      runDocker: async (args, hooks) => {
+        calls.push(args);
+        hooks.heartbeat?.();
+        return args[0] === "pull"
+          ? ""
+          : "docker.io/library/postgres@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n";
+      }
+    });
+    expect(image).toBe(`postgres:16@sha256:${"a".repeat(64)}`);
+    expect(calls.map((call) => call[0])).toEqual(["pull", "image"]);
+    expect(heartbeats).toBeGreaterThan(0);
+  });
+});

--- a/packages/server/src/worker/temporal/activities/external-postgres-artifact.ts
+++ b/packages/server/src/worker/temporal/activities/external-postgres-artifact.ts
@@ -254,14 +254,18 @@ const SUPPORTED_TOC_ENTRY_TYPES = new Set([
   "VIEW"
 ]);
 
+const ALL_TOC_ENTRY_TYPES_SORTED = [...UNSAFE_TOC_ENTRY_TYPES, ...SUPPORTED_TOC_ENTRY_TYPES].sort(
+  (left, right) => right.length - left.length
+);
+
 function extractTocEntryTypes(listing: string): string[] {
   const entries: string[] = [];
   for (const line of listing.split("\n")) {
     if (!/^\d+;/.test(line)) continue;
     const body = line.replace(/^\d+;\s*\d+\s+\d+\s+/, "");
-    const type = [...UNSAFE_TOC_ENTRY_TYPES, ...SUPPORTED_TOC_ENTRY_TYPES]
-      .sort((left, right) => right.length - left.length)
-      .find((candidate) => body === candidate || body.startsWith(`${candidate} `));
+    const type = ALL_TOC_ENTRY_TYPES_SORTED.find(
+      (candidate) => body === candidate || body.startsWith(`${candidate} `)
+    );
     if (!type) throw new Error("External artifact contains an unrecognized archive entry type.");
     entries.push(type);
   }

--- a/packages/server/src/worker/temporal/activities/external-postgres-artifact.ts
+++ b/packages/server/src/worker/temporal/activities/external-postgres-artifact.ts
@@ -1,0 +1,272 @@
+import { spawn } from "node:child_process";
+import { dockerCommand, withCommandPath } from "../../command-env";
+import {
+  listPostgresCustomArchive,
+  type PostgresRestoreVerifierHooks
+} from "./postgres-restore-verification";
+
+const OFFICIAL_IMAGE =
+  /^(?:(?:docker\.io\/)?library\/)?postgres:(?<tag>(?<major>[1-9]\d*)(?:\.\d+(?:\.\d+)?)?(?:-[a-z0-9][a-z0-9._-]*)?)@sha256:[a-f0-9]{64}$/i;
+const REPO_DIGEST = /^(?:(?:docker\.io\/)?library\/)?postgres@sha256:(?<digest>[a-f0-9]{64})$/i;
+const MAX_LISTING_EVIDENCE_CHARS = 48_000;
+
+export type ParsedExternalPostgresArchive = {
+  sourcePostgresVersion: string;
+  listingEvidence: string;
+};
+
+export type PostgresVerifierImageResolverOptions = {
+  runDocker?: (
+    args: string[],
+    input: { heartbeat?: () => void; cancellationSignal?: AbortSignal }
+  ) => Promise<string>;
+  heartbeat?: () => void;
+  cancellationSignal?: AbortSignal;
+};
+
+export async function resolveOfficialPostgresVerifierImage(
+  postgresMajor: string,
+  options: PostgresVerifierImageResolverOptions = {}
+): Promise<string> {
+  const major = normalizePostgresMajor(postgresMajor);
+  const configured = process.env[`DAOFLOW_POSTGRES_VERIFIER_IMAGE_${major}`]?.trim();
+  if (configured) return assertOfficialPostgresVerifierImage(configured, major);
+
+  const mutableTag = `postgres:${major}`;
+  const runDocker = options.runDocker ?? runDockerCommand;
+  try {
+    await runDocker(["pull", "--quiet", mutableTag], options);
+    const repoDigest = await runDocker(
+      ["image", "inspect", "--format", "{{index .RepoDigests 0}}", mutableTag],
+      options
+    );
+    const match = REPO_DIGEST.exec(repoDigest.trim());
+    if (!match?.groups?.digest) {
+      throw new Error("missing official repository digest");
+    }
+    return `postgres:${major}@sha256:${match.groups.digest}`;
+  } catch {
+    throw new Error("An immutable official PostgreSQL verifier image could not be resolved.");
+  }
+}
+
+export async function inspectExternalPostgresCustomArchive(input: {
+  artifactId: string;
+  dumpPath: string;
+  checksum: string;
+  expectedPostgresMajor: string;
+  verifierImage: string;
+  verifierHooks?: Partial<PostgresRestoreVerifierHooks>;
+}): Promise<ParsedExternalPostgresArchive> {
+  const major = normalizePostgresMajor(input.expectedPostgresMajor);
+  const verifierImage = assertOfficialPostgresVerifierImage(input.verifierImage, major);
+  const result = await listPostgresCustomArchive(
+    {
+      restoreId: input.artifactId,
+      localDumpPath: input.dumpPath,
+      expectedSha256: input.checksum,
+      sourcePostgresVersion: major,
+      verifierImage
+    },
+    input.verifierHooks
+  );
+  return parseExternalPostgresArchiveListing(result.listing, major);
+}
+
+export function parseExternalPostgresArchiveListing(
+  listing: string,
+  expectedPostgresMajor: string
+): ParsedExternalPostgresArchive {
+  const major = normalizePostgresMajor(expectedPostgresMajor);
+  const sanitized = sanitizePgRestoreListing(listing);
+  if (!/^;\s*Format:\s*Custom\s*$/im.test(sanitized)) {
+    throw new Error("External artifact is not a PostgreSQL custom-format archive.");
+  }
+  const source =
+    /^;\s*Dumped from database version:\s*(?<version>[1-9]\d*(?:\.\d+){0,2})(?:\s+\([^\r\n)]{1,200}\))?\s*$/im.exec(
+      sanitized
+    )?.groups?.version;
+  const sourceMajor = source?.split(".")[0];
+  if (!source || sourceMajor !== major) {
+    throw new Error("External artifact PostgreSQL version does not match the requested major.");
+  }
+
+  for (const entry of extractTocEntryTypes(sanitized)) {
+    if (UNSAFE_TOC_ENTRY_TYPES.has(entry)) {
+      throw new Error(`External artifact contains unsupported archive entry type: ${entry}.`);
+    }
+    if (!SUPPORTED_TOC_ENTRY_TYPES.has(entry)) {
+      throw new Error(`External artifact contains an unrecognized archive entry type: ${entry}.`);
+    }
+  }
+
+  return { sourcePostgresVersion: source, listingEvidence: sanitized };
+}
+
+export function sanitizePgRestoreListing(listing: string): string {
+  if (typeof listing !== "string" || listing.length === 0) {
+    throw new Error("PostgreSQL archive listing is empty.");
+  }
+  const cleaned = stripUnsafeControlCharacters(listing)
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^\s/@]+(?::[^\s/@]+)?@/gi, "$1[redacted]@")
+    .replace(
+      /\b(password|passwd|secret|token|api[_-]?key|credential)\s*([=:])\s*[^\s,;]+/gi,
+      "$1$2[redacted]"
+    )
+    .split("\n")
+    .map((line) => line.trimEnd().slice(0, 500))
+    .filter((line) => line.length > 0)
+    .join("\n");
+  if (!cleaned) throw new Error("PostgreSQL archive listing is empty.");
+  return cleaned.slice(0, MAX_LISTING_EVIDENCE_CHARS);
+}
+
+function stripUnsafeControlCharacters(value: string): string {
+  return [...value]
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127);
+    })
+    .join("");
+}
+
+function normalizePostgresMajor(value: string): string {
+  const major = value.trim();
+  if (!/^[1-9]\d*$/.test(major)) {
+    throw new Error("PostgreSQL major version must be a positive integer.");
+  }
+  return major;
+}
+
+function assertOfficialPostgresVerifierImage(image: string, expectedMajor: string): string {
+  const match = OFFICIAL_IMAGE.exec(image.trim());
+  if (!match?.groups?.major || match.groups.major !== expectedMajor) {
+    throw new Error(
+      "Verifier image must be an immutable official PostgreSQL image for the requested major."
+    );
+  }
+  return image.trim();
+}
+
+function runDockerCommand(
+  args: string[],
+  input: { heartbeat?: () => void; cancellationSignal?: AbortSignal }
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(dockerCommand, args, {
+      env: withCommandPath(process.env),
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    let stdout = "";
+    let settled = false;
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      clearInterval(heartbeatTimer);
+      removeAbortListener?.();
+      callback();
+    };
+    const heartbeat = () => input.heartbeat?.();
+    heartbeat();
+    const heartbeatTimer = setInterval(heartbeat, 15_000);
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      settle(() => reject(new Error("Verifier image pull timed out.")));
+    }, 300_000);
+    const abort = () => {
+      child.kill("SIGTERM");
+      settle(() => reject(new Error("Verifier image pull was cancelled.")));
+    };
+    const removeAbortListener = input.cancellationSignal
+      ? () => input.cancellationSignal?.removeEventListener("abort", abort)
+      : undefined;
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.on("error", () => settle(() => reject(new Error("Verifier image command failed."))));
+    child.on("close", (code) =>
+      settle(() =>
+        code === 0 ? resolve(stdout) : reject(new Error("Verifier image command failed."))
+      )
+    );
+    if (input.cancellationSignal) {
+      if (input.cancellationSignal.aborted) abort();
+      else input.cancellationSignal.addEventListener("abort", abort, { once: true });
+    }
+  });
+}
+
+const UNSAFE_TOC_ENTRY_TYPES = new Set([
+  "DATABASE",
+  "TABLESPACE",
+  "BLOB",
+  "BLOB DATA",
+  "BLOBS",
+  "BLOBS DATA",
+  "FOREIGN DATA WRAPPER",
+  "FOREIGN SERVER",
+  "USER MAPPING",
+  "SUBSCRIPTION",
+  "PUBLICATION",
+  "EVENT TRIGGER",
+  "SECURITY LABEL"
+]);
+
+const SUPPORTED_TOC_ENTRY_TYPES = new Set([
+  "ACL",
+  "AGGREGATE",
+  "CAST",
+  "CHECK CONSTRAINT",
+  "COLLATION",
+  "COMMENT",
+  "CONSTRAINT",
+  "CONVERSION",
+  "DEFAULT",
+  "DEFAULT ACL",
+  "DOMAIN",
+  "EXTENSION",
+  "EXTENSION COMMENT",
+  "FK CONSTRAINT",
+  "FUNCTION",
+  "INDEX",
+  "MATERIALIZED VIEW",
+  "MATERIALIZED VIEW DATA",
+  "OPERATOR",
+  "OPERATOR CLASS",
+  "OPERATOR FAMILY",
+  "POLICY",
+  "PROCEDURE",
+  "RULE",
+  "SCHEMA",
+  "SEQUENCE",
+  "SEQUENCE OWNED BY",
+  "SEQUENCE SET",
+  "SHELL TYPE",
+  "TABLE",
+  "TABLE DATA",
+  "TEXT SEARCH CONFIGURATION",
+  "TEXT SEARCH DICTIONARY",
+  "TEXT SEARCH PARSER",
+  "TEXT SEARCH TEMPLATE",
+  "TRIGGER",
+  "TYPE",
+  "VIEW"
+]);
+
+function extractTocEntryTypes(listing: string): string[] {
+  const entries: string[] = [];
+  for (const line of listing.split("\n")) {
+    if (!/^\d+;/.test(line)) continue;
+    const body = line.replace(/^\d+;\s*\d+\s+\d+\s+/, "");
+    const type = [...UNSAFE_TOC_ENTRY_TYPES, ...SUPPORTED_TOC_ENTRY_TYPES]
+      .sort((left, right) => right.length - left.length)
+      .find((candidate) => body === candidate || body.startsWith(`${candidate} `));
+    if (!type) throw new Error("External artifact contains an unrecognized archive entry type.");
+    entries.push(type);
+  }
+  if (entries.length === 0) {
+    throw new Error("PostgreSQL archive listing did not contain any table-of-contents entries.");
+  }
+  return entries;
+}

--- a/packages/server/src/worker/temporal/activities/postgres-restore-verification.ts
+++ b/packages/server/src/worker/temporal/activities/postgres-restore-verification.ts
@@ -80,6 +80,37 @@ export function createPostgresRestoreVerifier(
   const hooks = { ...defaultPostgresRestoreVerifierHooks, ...overrides };
   return { verify: (input) => verify(input, hooks) };
 }
+
+/**
+ * Run only the same locked-down pg_restore --list preflight used by the
+ * isolated verifier. External artifact registration stores a sanitized result
+ * from this helper before the artifact can be restored anywhere.
+ */
+export async function listPostgresCustomArchive(
+  input: PostgresRestoreVerificationInput,
+  overrides: Partial<PostgresRestoreVerifierHooks> = {}
+): Promise<{ listing: string }> {
+  const hooks = { ...defaultPostgresRestoreVerifierHooks, ...overrides };
+  const startedAt = hooks.now();
+  try {
+    const valid = validatePostgresVerificationInput(input);
+    await beforePostgresVerificationDeadline(
+      hooks,
+      startedAt,
+      verificationCommand(["image", "inspect", input.verifierImage]),
+      "Verifier image inspection failed."
+    );
+    const listing = await beforePostgresVerificationDeadline(
+      hooks,
+      startedAt,
+      archiveInspectionCommand(input.verifierImage, valid.dumpPath),
+      "Custom-format archive inspection failed."
+    );
+    return { listing: listing.stdout };
+  } catch (error) {
+    throw new Error(redactError(error));
+  }
+}
 async function verify(
   input: PostgresRestoreVerificationInput,
   hooks: PostgresRestoreVerifierHooks

--- a/packages/server/src/worker/temporal/activities/restore-database-hooks.test.ts
+++ b/packages/server/src/worker/temporal/activities/restore-database-hooks.test.ts
@@ -1,0 +1,165 @@
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  collectDockerJsonLines: vi.fn(),
+  runCancellableLocalCommand: vi.fn(),
+  spawn: vi.fn(),
+  sshArgs: vi.fn((target: { host: string }) => ["--target", target.host])
+}));
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: mocks.spawn
+}));
+
+vi.mock("../../server-host-command", () => ({
+  collectDockerJsonLines: mocks.collectDockerJsonLines
+}));
+
+vi.mock("../../cancellable-local-command", () => ({
+  runCancellableLocalCommand: mocks.runCancellableLocalCommand
+}));
+
+vi.mock("../../ssh-connection", () => ({
+  shellQuote: (value: string) => value,
+  sshArgs: mocks.sshArgs
+}));
+
+import { restoreDatabaseTestHooks } from "./restore-database";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  while (roots.length > 0) rmSync(roots.pop() as string, { recursive: true, force: true });
+  mocks.collectDockerJsonLines.mockReset();
+  mocks.runCancellableLocalCommand.mockReset();
+  mocks.spawn.mockReset();
+  mocks.sshArgs.mockClear();
+});
+
+function dumpFile() {
+  const root = mkdtempSync(join(tmpdir(), "daoflow-restore-hook-"));
+  roots.push(root);
+  const path = join(root, "dump.custom");
+  writeFileSync(path, "dump");
+  return path;
+}
+
+function child() {
+  const process = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  process.stdin = new PassThrough();
+  process.stdout = new PassThrough();
+  process.stderr = new PassThrough();
+  process.kill = vi.fn();
+  return process;
+}
+
+describe("external database restore process hooks", () => {
+  it("heartbeats during a long restore before the Temporal heartbeat deadline", async () => {
+    vi.useFakeTimers();
+    let completeRestore: (() => void) | undefined;
+    mocks.runCancellableLocalCommand.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          completeRestore = resolve;
+        })
+    );
+    let heartbeats = 0;
+    const pending = restoreDatabaseTestHooks.runDockerDatabaseRestore(
+      { mode: "local" },
+      "postgres-container",
+      { envArgs: [], args: ["pg_restore"] },
+      dumpFile(),
+      { heartbeat: () => heartbeats++, timeoutMs: 60_000 }
+    );
+    await vi.advanceTimersByTimeAsync(15_000);
+    completeRestore?.();
+    await expect(pending).resolves.toBeUndefined();
+    expect(heartbeats).toBeGreaterThanOrEqual(2);
+  });
+
+  it("cancels the docker process and rejects instead of allowing a duplicate retry", async () => {
+    const process = child();
+    mocks.spawn.mockReturnValue(process);
+    const controller = new AbortController();
+    const pending = restoreDatabaseTestHooks.runDockerDatabaseRestore(
+      {
+        mode: "remote",
+        serverKind: "docker-engine",
+        remoteWorkDir: "/tmp/restore",
+        ssh: { serverName: "production", host: "203.0.113.8", port: 22 }
+      },
+      "postgres-container",
+      { envArgs: [], args: ["pg_restore"] },
+      dumpFile(),
+      { cancellationSignal: controller.signal }
+    );
+    controller.abort();
+    await expect(pending).rejects.toThrow("cancelled");
+    expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("resolves the concrete local Compose container before restoring", async () => {
+    mocks.collectDockerJsonLines.mockResolvedValue({
+      exitCode: 0,
+      stdout: ["project-postgres-1"],
+      stderr: []
+    });
+
+    await expect(
+      restoreDatabaseTestHooks.resolveDatabaseContainer({
+        databaseEngine: "postgres",
+        volumeName: "postgres-data",
+        executionTarget: { mode: "local" },
+        runtime: {
+          kind: "compose",
+          projectName: "project",
+          serviceName: "postgres"
+        }
+      })
+    ).resolves.toBe("project-postgres-1");
+
+    expect(mocks.collectDockerJsonLines).toHaveBeenCalledWith(
+      { mode: "local" },
+      expect.arrayContaining([
+        "label=com.docker.compose.project=project",
+        "label=com.docker.compose.service=postgres"
+      ])
+    );
+  });
+
+  it("streams pg_restore through SSH when the approved target is remote", () => {
+    const process = child();
+    mocks.spawn.mockReturnValue(process);
+    const target = {
+      mode: "remote" as const,
+      serverKind: "docker-engine",
+      remoteWorkDir: "/tmp/restore",
+      ssh: { serverName: "production", host: "203.0.113.8", port: 22 }
+    };
+
+    restoreDatabaseTestHooks.spawnTargetDockerCommand(target, [
+      "exec",
+      "-i",
+      "project-postgres-1",
+      "pg_restore"
+    ]);
+
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      expect.any(String),
+      ["--target", "203.0.113.8", expect.stringContaining("exec -i project-postgres-1 pg_restore")],
+      expect.objectContaining({ stdio: ["pipe", "pipe", "pipe"] })
+    );
+  });
+});

--- a/packages/server/src/worker/temporal/activities/restore-database.ts
+++ b/packages/server/src/worker/temporal/activities/restore-database.ts
@@ -1,10 +1,13 @@
-import { statSync } from "node:fs";
-import { dockerCommand, withCommandPath } from "../../command-env";
+import { spawn } from "node:child_process";
+import { createReadStream, statSync } from "node:fs";
 import { runCancellableLocalCommand } from "../../cancellable-local-command";
-import { processRunner } from "../../process-runner";
+import { dockerCommand, sshCommand, withCommandPath } from "../../command-env";
+import type { ExecutionTarget } from "../../execution-target";
+import { collectDockerJsonLines } from "../../server-host-command";
+import { shellQuote, sshArgs } from "../../ssh-connection";
 import { redactActivitySecretValue } from "./activity-secret-redaction";
 import { findLargestFile } from "./restore-files";
-import type { RestoreExecutionContext, RestoreExecutionResult } from "./restore-execution";
+import type { RestoreExecutionResult } from "./restore-execution";
 
 interface DockerRestoreCommand {
   envArgs: string[];
@@ -13,13 +16,36 @@ interface DockerRestoreCommand {
 
 type DatabaseEngine = "postgres" | "mysql" | "mariadb" | "mongo";
 
+export type DatabaseRestoreRuntime =
+  | { kind: "container"; containerName: string }
+  | { kind: "compose"; projectName: string; serviceName: string };
+
+export type DatabaseRestoreContext = {
+  databaseEngine?: string;
+  databasePassword?: string;
+  databaseUser?: string;
+  databaseName?: string;
+  containerName?: string;
+  serviceName?: string;
+  volumeName: string;
+  executionTarget?: ExecutionTarget;
+  runtime?: DatabaseRestoreRuntime;
+};
+
+export type DatabaseRestoreHooks = {
+  heartbeat?: () => void;
+  cancellationSignal?: AbortSignal;
+  timeoutMs?: number;
+};
+
 export async function executeDatabaseRestore(
-  ctx: RestoreExecutionContext,
+  ctx: DatabaseRestoreContext,
   localPath: string,
-  signal?: AbortSignal
+  hooksOrSignal: DatabaseRestoreHooks | AbortSignal = {}
 ): Promise<RestoreExecutionResult> {
+  const hooks = normalizeRestoreHooks(hooksOrSignal);
   try {
-    throwIfCancelled(signal);
+    throwIfCancelled(hooks.cancellationSignal);
     const engine = normalizeDatabaseEngine(ctx.databaseEngine);
     if (!engine) {
       return {
@@ -38,7 +64,7 @@ export async function executeDatabaseRestore(
       };
     }
 
-    const containerName = resolveDatabaseContainer(ctx);
+    const containerName = await resolveDatabaseContainer(ctx);
     if (!containerName) {
       return {
         success: false,
@@ -49,14 +75,15 @@ export async function executeDatabaseRestore(
     }
 
     await runDockerDatabaseRestore(
+      ctx.executionTarget ?? { mode: "local" },
       containerName,
       buildRestoreCommand(ctx, engine),
       dumpFile,
-      signal
+      hooks
     );
     return { success: true, bytesRestored: statSync(dumpFile).size };
   } catch (err) {
-    throwIfCancelled(signal);
+    throwIfCancelled(hooks.cancellationSignal);
     return {
       success: false,
       bytesRestored: 0,
@@ -68,6 +95,29 @@ export async function executeDatabaseRestore(
   }
 }
 
+function normalizeRestoreHooks(
+  hooksOrSignal: DatabaseRestoreHooks | AbortSignal
+): DatabaseRestoreHooks {
+  if (isAbortSignal(hooksOrSignal)) {
+    return { cancellationSignal: hooksOrSignal };
+  }
+  return hooksOrSignal;
+}
+
+function isAbortSignal(
+  hooksOrSignal: DatabaseRestoreHooks | AbortSignal
+): hooksOrSignal is AbortSignal {
+  return "aborted" in hooksOrSignal && typeof hooksOrSignal.addEventListener === "function";
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error("Database restore was cancelled.");
+  }
+}
+
 function normalizeDatabaseEngine(engine: string | undefined): DatabaseEngine | null {
   if (engine === "postgres" || engine === "mysql" || engine === "mariadb" || engine === "mongo") {
     return engine;
@@ -76,7 +126,7 @@ function normalizeDatabaseEngine(engine: string | undefined): DatabaseEngine | n
 }
 
 function buildRestoreCommand(
-  ctx: RestoreExecutionContext,
+  ctx: DatabaseRestoreContext,
   engine: DatabaseEngine
 ): DockerRestoreCommand {
   switch (engine) {
@@ -124,80 +174,140 @@ function buildRestoreCommand(
 }
 
 function runDockerDatabaseRestore(
+  target: ExecutionTarget,
   containerName: string,
   command: DockerRestoreCommand,
   dumpFile: string,
-  signal?: AbortSignal
+  hooks: DatabaseRestoreHooks
 ): Promise<void> {
   const args = ["exec", "-i", ...command.envArgs, containerName, ...command.args];
-  return runCancellableLocalCommand(dockerCommand, args, {
-    description: "Database restore failed",
-    timeoutMs: 1_800_000,
-    signal,
-    env: withCommandPath(process.env),
-    stdinFilePath: dumpFile
+  if (target.mode === "local") {
+    return runLocalDockerDatabaseRestore(args, dumpFile, hooks);
+  }
+
+  return new Promise((resolve, reject) => {
+    const input = createReadStream(dumpFile);
+    const proc = spawnTargetDockerCommand(target, args, hooks.cancellationSignal);
+    let settled = false;
+    const stopInput = () => {
+      input.unpipe(proc.stdin);
+      input.destroy();
+    };
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      clearInterval(heartbeatTimer);
+      removeAbortListener?.();
+      callback();
+    };
+    const timeout = setTimeout(() => {
+      stopInput();
+      proc.kill("SIGTERM");
+      settle(() => reject(new Error("Database restore timed out after 30 minutes")));
+    }, hooks.timeoutMs ?? 1_800_000);
+    const heartbeat = () => hooks.heartbeat?.();
+    heartbeat();
+    const heartbeatTimer = setInterval(heartbeat, 15_000);
+    const abort = () => {
+      stopInput();
+      proc.kill("SIGTERM");
+      settle(() => reject(new Error("Database restore was cancelled.")));
+    };
+    const removeAbortListener = hooks.cancellationSignal
+      ? () => hooks.cancellationSignal?.removeEventListener("abort", abort)
+      : undefined;
+    let stderr = "";
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    proc.on("error", (error) => {
+      stopInput();
+      settle(() => reject(error));
+    });
+    proc.on("close", (code) => {
+      stopInput();
+      settle(() =>
+        code === 0
+          ? resolve()
+          : reject(
+              new Error(`docker exec restore exited with code ${code}: ${stderr.slice(0, 500)}`)
+            )
+      );
+    });
+
+    input.on("error", (error) => {
+      stopInput();
+      proc.kill("SIGTERM");
+      settle(() => reject(error));
+    });
+    input.pipe(proc.stdin);
+    if (hooks.cancellationSignal) {
+      if (hooks.cancellationSignal.aborted) abort();
+      else hooks.cancellationSignal.addEventListener("abort", abort, { once: true });
+    }
   });
 }
 
-function throwIfCancelled(signal?: AbortSignal): void {
-  if (signal?.aborted) {
-    throw signal.reason instanceof Error
-      ? signal.reason
-      : new Error("Database restore was cancelled.");
+async function runLocalDockerDatabaseRestore(
+  args: string[],
+  dumpFile: string,
+  hooks: DatabaseRestoreHooks
+): Promise<void> {
+  const heartbeat = () => hooks.heartbeat?.();
+  heartbeat();
+  const heartbeatTimer = setInterval(heartbeat, 15_000);
+  try {
+    await runCancellableLocalCommand(dockerCommand, args, {
+      description: "Database restore failed",
+      timeoutMs: hooks.timeoutMs ?? 1_800_000,
+      signal: hooks.cancellationSignal,
+      env: withCommandPath(process.env),
+      stdinFilePath: dumpFile
+    });
+  } finally {
+    clearInterval(heartbeatTimer);
   }
 }
 
-function resolveDatabaseContainer(ctx: RestoreExecutionContext): string | null {
+function spawnTargetDockerCommand(target: ExecutionTarget, args: string[], signal?: AbortSignal) {
+  if (target.mode === "local") {
+    return spawn(dockerCommand, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: withCommandPath(process.env),
+      signal
+    });
+  }
+  const remoteCommand = [dockerCommand, ...args].map((arg) => shellQuote(arg)).join(" ");
+  return spawn(sshCommand, [...sshArgs(target.ssh), remoteCommand], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: withCommandPath(process.env),
+    signal
+  });
+}
+
+async function resolveDatabaseContainer(ctx: DatabaseRestoreContext): Promise<string | null> {
   if (ctx.containerName) {
     return ctx.containerName;
   }
-
-  for (const candidate of [ctx.serviceName, ctx.volumeName].filter(Boolean)) {
-    const byComposeService = firstDockerContainer([
-      "ps",
-      "--format",
-      "{{.Names}}",
-      "--filter",
-      `label=com.docker.compose.service=${candidate}`
-    ]);
-    if (byComposeService) {
-      return byComposeService;
-    }
-
-    const byName = firstDockerContainer([
-      "ps",
-      "--format",
-      "{{.Names}}",
-      "--filter",
-      `name=${candidate}`
-    ]);
-    if (byName) {
-      return byName;
-    }
+  if (ctx.runtime?.kind === "container") return ctx.runtime.containerName;
+  const serviceName = ctx.runtime?.kind === "compose" ? ctx.runtime.serviceName : ctx.serviceName;
+  if (!serviceName) return null;
+  const args = ["ps", "--format", "{{.Names}}"];
+  if (ctx.runtime?.kind === "compose") {
+    args.push("--filter", `label=com.docker.compose.project=${ctx.runtime.projectName}`);
   }
-
-  return null;
-}
-
-function firstDockerContainer(args: string[]): string | null {
-  try {
-    const output = processRunner.execFileSync(dockerCommand, args, {
-      encoding: "utf-8",
-      timeout: 10_000,
-      env: withCommandPath(process.env)
-    });
-    return (
-      output
-        .split("\n")
-        .map((line) => line.trim())
-        .find(Boolean) ?? null
-    );
-  } catch {
-    return null;
-  }
+  args.push("--filter", `label=com.docker.compose.service=${serviceName}`);
+  const result = await collectDockerJsonLines(ctx.executionTarget ?? { mode: "local" }, args);
+  const names = result.stdout.map((line) => line.trim()).filter(Boolean);
+  return result.exitCode === 0 && names.length === 1 ? names[0] : null;
 }
 
 export const restoreDatabaseTestHooks = {
   buildRestoreCommand,
-  normalizeDatabaseEngine
+  normalizeDatabaseEngine,
+  resolveDatabaseContainer,
+  runDockerDatabaseRestore,
+  spawnTargetDockerCommand
 };

--- a/packages/server/src/worker/temporal/client.ts
+++ b/packages/server/src/worker/temporal/client.ts
@@ -15,6 +15,11 @@ import {
 import type { DeploymentWorkflowInput } from "../deployment-workflow-input";
 import { TEMPORAL_ADDRESS, TEMPORAL_NAMESPACE, TEMPORAL_TASK_QUEUE } from "./temporal-config";
 import type { RestoreApproval } from "./restore-workflow-input";
+import type {
+  ExternalArtifactImportWorkflowInput,
+  ExternalArtifactRestoreWorkflowInput,
+  ExternalArtifactVerificationWorkflowInput
+} from "./external-artifact-workflow-input";
 
 let client: Client | null = null;
 export const DEPLOYMENT_WORKFLOW_EXECUTION_TIMEOUT = "7 days";
@@ -118,6 +123,18 @@ export function buildOneOffBackupWorkflowId(policyId: string, requestedRunId?: s
 
 export function buildRestoreWorkflowId(restoreId: string): string {
   return `backup-restore-${restoreId}`;
+}
+
+export function buildExternalArtifactImportWorkflowId(artifactId: string): string {
+  return `external-artifact-import-${artifactId}`;
+}
+
+export function buildExternalArtifactVerificationWorkflowId(restoreId: string): string {
+  return `external-artifact-verify-${restoreId}`;
+}
+
+export function buildExternalArtifactRestoreWorkflowId(restoreId: string): string {
+  return `external-artifact-restore-${restoreId}`;
 }
 
 /**
@@ -245,6 +262,68 @@ export async function startRestoreWorkflow(input: {
   } catch (error) {
     if (!(error instanceof WorkflowExecutionAlreadyStartedError)) throw error;
 
+    const existing = tc.workflow.getHandle(workflowId);
+    const description = await existing.describe();
+    return { workflowId, runId: description.runId };
+  }
+}
+
+export async function startExternalArtifactImportWorkflow(
+  input: ExternalArtifactImportWorkflowInput
+): Promise<{ workflowId: string; runId: string }> {
+  return startExternalArtifactWorkflow(
+    "externalArtifactImportWorkflow",
+    buildExternalArtifactImportWorkflowId(input.artifactId),
+    input,
+    WorkflowIdReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY
+  );
+}
+
+export async function startExternalArtifactVerificationWorkflow(
+  input: ExternalArtifactVerificationWorkflowInput
+): Promise<{ workflowId: string; runId: string }> {
+  return startExternalArtifactWorkflow(
+    "externalArtifactVerificationWorkflow",
+    buildExternalArtifactVerificationWorkflowId(input.restoreId),
+    input
+  );
+}
+
+export async function startExternalArtifactRestoreWorkflow(
+  input: ExternalArtifactRestoreWorkflowInput
+): Promise<{ workflowId: string; runId: string }> {
+  return startExternalArtifactWorkflow(
+    "externalArtifactRestoreWorkflow",
+    buildExternalArtifactRestoreWorkflowId(input.restoreId),
+    input
+  );
+}
+
+async function startExternalArtifactWorkflow(
+  workflowType:
+    | "externalArtifactImportWorkflow"
+    | "externalArtifactVerificationWorkflow"
+    | "externalArtifactRestoreWorkflow",
+  workflowId: string,
+  input:
+    | ExternalArtifactImportWorkflowInput
+    | ExternalArtifactVerificationWorkflowInput
+    | ExternalArtifactRestoreWorkflowInput,
+  workflowIdReusePolicy: WorkflowIdReusePolicy = WorkflowIdReusePolicy.REJECT_DUPLICATE
+): Promise<{ workflowId: string; runId: string }> {
+  const tc = await getTemporalClient();
+  try {
+    const handle = await tc.workflow.start(workflowType, {
+      taskQueue: TEMPORAL_TASK_QUEUE,
+      workflowId,
+      args: [input],
+      workflowExecutionTimeout: "1h",
+      workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+      workflowIdReusePolicy
+    });
+    return { workflowId: handle.workflowId, runId: handle.firstExecutionRunId };
+  } catch (error) {
+    if (!(error instanceof WorkflowExecutionAlreadyStartedError)) throw error;
     const existing = tc.workflow.getHandle(workflowId);
     const description = await existing.describe();
     return { workflowId, runId: description.runId };

--- a/packages/server/src/worker/temporal/external-artifact-workflow-input.ts
+++ b/packages/server/src/worker/temporal/external-artifact-workflow-input.ts
@@ -1,0 +1,44 @@
+export interface ExternalArtifactRestoreApprovalSnapshot {
+  artifactId: string;
+  artifactSha256: string;
+  artifactObjectKey: string;
+  artifactObjectVersion: string;
+  artifactObjectEtag: string;
+  artifactVerifiedAt: string;
+  destinationId: string;
+  destinationUpdatedAt: string;
+  targetVolumeId: string;
+  targetVolumeUpdatedAt: string;
+  targetServerId: string;
+  targetMountPath: string;
+  targetServiceId: string;
+  targetServiceUpdatedAt: string;
+  runtimeServiceName: string;
+  databaseEngine: "postgres";
+  databaseName: string;
+  databaseUser: string;
+  secretPolicy: "destination-credentials-encrypted";
+}
+
+export interface ExternalArtifactRestoreApproval {
+  approvalRequestId: string;
+  expectedTeamId: string;
+  snapshot: ExternalArtifactRestoreApprovalSnapshot;
+}
+
+export interface ExternalArtifactImportWorkflowInput {
+  artifactId: string;
+  destinationUpdatedAt: string;
+}
+
+export interface ExternalArtifactVerificationWorkflowInput {
+  artifactId: string;
+  restoreId: string;
+}
+
+export interface ExternalArtifactRestoreWorkflowInput {
+  artifactId: string;
+  restoreId: string;
+  targetVolumeId: string;
+  approval: ExternalArtifactRestoreApproval;
+}

--- a/packages/server/src/worker/temporal/worker.ts
+++ b/packages/server/src/worker/temporal/worker.ts
@@ -16,6 +16,7 @@ import * as retentionActivities from "./activities/retention-activities";
 import * as notificationActivities from "./activities/notification-activities";
 import * as restoreActivities from "./activities/restore-activities";
 import * as controlPlaneRecoveryActivities from "./activities/control-plane-recovery-activities";
+import * as externalArtifactActivities from "./activities/external-backup-artifact-activities";
 import { resolve } from "node:path";
 import { TEMPORAL_ADDRESS, TEMPORAL_NAMESPACE, TEMPORAL_TASK_QUEUE } from "./temporal-config";
 
@@ -27,7 +28,8 @@ const activities = {
   ...retentionActivities,
   ...notificationActivities,
   ...restoreActivities,
-  ...controlPlaneRecoveryActivities
+  ...controlPlaneRecoveryActivities,
+  ...externalArtifactActivities
 };
 
 let worker: Worker | null = null;

--- a/packages/server/src/worker/temporal/workflows/external-backup-artifact-workflows.test.ts
+++ b/packages/server/src/worker/temporal/workflows/external-backup-artifact-workflows.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const executeRestore = vi.fn();
+  return {
+    executeRestore,
+    proxyActivities: vi
+      .fn()
+      .mockReturnValueOnce({
+        importExternalBackupArtifact: vi.fn(),
+        verifyExternalBackupArtifact: vi.fn()
+      })
+      .mockReturnValueOnce({ executeExternalArtifactRestore: executeRestore })
+  };
+});
+
+vi.mock("@temporalio/workflow", () => ({
+  proxyActivities: mocks.proxyActivities
+}));
+
+import { externalArtifactRestoreWorkflow } from "./external-backup-artifact-workflows";
+
+describe("external artifact restore workflow", () => {
+  it("does not retry the destructive production restore activity", async () => {
+    const input = {
+      artifactId: "xart_1",
+      restoreId: "brest_1",
+      targetVolumeId: "vol_1",
+      approval: {}
+    } as never;
+
+    await externalArtifactRestoreWorkflow(input);
+
+    expect(mocks.proxyActivities).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ retry: { maximumAttempts: 1 } })
+    );
+    expect(mocks.executeRestore).toHaveBeenCalledTimes(1);
+    expect(mocks.executeRestore).toHaveBeenCalledWith(input);
+  });
+});

--- a/packages/server/src/worker/temporal/workflows/external-backup-artifact-workflows.ts
+++ b/packages/server/src/worker/temporal/workflows/external-backup-artifact-workflows.ts
@@ -1,0 +1,44 @@
+import { proxyActivities } from "@temporalio/workflow";
+import type * as externalArtifactActivities from "../activities/external-backup-artifact-activities";
+import type {
+  ExternalArtifactImportWorkflowInput,
+  ExternalArtifactRestoreWorkflowInput,
+  ExternalArtifactVerificationWorkflowInput
+} from "../external-artifact-workflow-input";
+
+const { importExternalBackupArtifact, verifyExternalBackupArtifact } = proxyActivities<
+  typeof externalArtifactActivities
+>({
+  startToCloseTimeout: "60 minutes",
+  retry: {
+    maximumAttempts: 2,
+    backoffCoefficient: 2,
+    initialInterval: "30s",
+    maximumInterval: "5m"
+  },
+  heartbeatTimeout: "2 minutes"
+});
+
+const { executeExternalArtifactRestore } = proxyActivities<typeof externalArtifactActivities>({
+  startToCloseTimeout: "60 minutes",
+  heartbeatTimeout: "2 minutes",
+  retry: { maximumAttempts: 1 }
+});
+
+export async function externalArtifactImportWorkflow(
+  input: ExternalArtifactImportWorkflowInput
+): Promise<void> {
+  await importExternalBackupArtifact(input);
+}
+
+export async function externalArtifactVerificationWorkflow(
+  input: ExternalArtifactVerificationWorkflowInput
+): Promise<void> {
+  await verifyExternalBackupArtifact(input);
+}
+
+export async function externalArtifactRestoreWorkflow(
+  input: ExternalArtifactRestoreWorkflowInput
+): Promise<void> {
+  await executeExternalArtifactRestore(input);
+}

--- a/packages/server/src/worker/temporal/workflows/index.ts
+++ b/packages/server/src/worker/temporal/workflows/index.ts
@@ -9,3 +9,8 @@ export { deploymentWorkflow } from "./deploy-workflow";
 export { backupCronWorkflow } from "./backup-workflow";
 export { restoreWorkflow } from "./restore-workflow";
 export { controlPlaneRecoveryWorkflow } from "./control-plane-recovery-workflow";
+export {
+  externalArtifactImportWorkflow,
+  externalArtifactVerificationWorkflow,
+  externalArtifactRestoreWorkflow
+} from "./external-backup-artifact-workflows";

--- a/scripts/external-contract-metadata.ts
+++ b/scripts/external-contract-metadata.ts
@@ -241,7 +241,15 @@ addApiGroup(
 
 addApiGroup(
   apiProcedureAccess,
-  ["backupOverview", "backupRestoreQueue", "backupRunDetails", "serviceBackupWorkflow"],
+  [
+    "backupOverview",
+    "backupRestoreQueue",
+    "backupRunDetails",
+    "serviceBackupWorkflow",
+    "externalBackupObjects",
+    "externalBackupArtifacts",
+    "externalBackupArtifact"
+  ],
   {
     auth: "authenticated",
     requiredRoles: READ_ROLES,
@@ -256,6 +264,13 @@ apiProcedureAccess.persistentVolumes = {
 };
 
 apiProcedureAccess.backupRestorePlan = {
+  auth: "authenticated",
+  laneOverride: "planning",
+  requiredRoles: READ_ROLES,
+  requiredScopes: ["backup:read"]
+};
+
+apiProcedureAccess.externalArtifactRestorePlan = {
   auth: "authenticated",
   laneOverride: "planning",
   requiredRoles: READ_ROLES,
@@ -431,6 +446,22 @@ addApiGroup(
     requiredScopes: ["backup:run"]
   }
 );
+
+addApiGroup(
+  apiProcedureAccess,
+  ["registerExternalBackupArtifact", "triggerExternalArtifactTestRestore"],
+  {
+    auth: "authenticated",
+    requiredRoles: OPS_ROLES,
+    requiredScopes: ["backup:restore"]
+  }
+);
+
+apiProcedureAccess.requestExternalArtifactRestoreApproval = {
+  auth: "authenticated",
+  requiredRoles: OPS_ROLES,
+  requiredScopes: ["approvals:create", "backup:restore"]
+};
 
 addApiGroup(apiProcedureAccess, ["upsertEnvironmentVariable", "deleteEnvironmentVariable"], {
   auth: "authenticated",
@@ -990,7 +1021,32 @@ export const cliCommandMeta: Record<string, CliCommandMeta> = {
   },
   "backup verify": { lane: "command", requiredScopes: ["backup:restore"], mutating: true },
   "backup download": { lane: "read", requiredScopes: ["backup:read"], mutating: false },
+  "backup external list": {
+    lane: "read",
+    requiredScopes: ["backup:read"],
+    mutating: false
+  },
+  "backup external register": {
+    lane: "command",
+    requiredScopes: ["backup:restore"],
+    mutating: true
+  },
+  "backup external verify": {
+    lane: "command",
+    requiredScopes: ["backup:restore"],
+    mutating: true
+  },
+  "backup external restore": {
+    lane: "command",
+    requiredScopes: ["approvals:create", "backup:restore"],
+    mutating: true
+  },
   "backup destination add": { lane: "command", requiredScopes: ["backup:run"], mutating: true },
+  "backup destination files": {
+    lane: "read",
+    requiredScopes: ["backup:read"],
+    mutating: false
+  },
   "backup destination delete": {
     lane: "command",
     requiredScopes: ["backup:run"],


### PR DESCRIPTION
Closes #218

Agent #2 implementation.

## What changed
- Adds opt-in, prefix-bounded S3 archive discovery and registration with pinned object identity and SHA-256 evidence.
- Validates PostgreSQL custom-format dumps, runs isolated test restores, and keeps external artifacts separate from DaoFlow backup runs.
- Requires a two-person approval before restoring to a selected managed PostgreSQL target.
- Adds CLI/UI flows, generated contracts, Drizzle migration, and operator documentation.

## Validation
- Format, lint, typecheck, contracts, skills, and Drizzle checks passed.
- Full server coverage completed in bounded shards; one unrelated audit-order assertion was rerun alone and passed.
- Client: 76 files / 232 tests passed.
- CLI: 57 files / 300 tests passed.
- MCP: 8 tests passed.
- Documentation production build passed.
- Sol self-review fix loop completed; ACPX intentionally skipped per user instruction.

## Isolated QA
Deployed the local image to `debian@192.168.3.112` as Compose project `daoflow-agent2-218` on port 3218. Verified:
- approved-prefix filtering and connection test against isolated MinIO;
- plain SQL rejection;
- PostgreSQL 17 custom-dump registration and checksum pinning;
- isolated restore verification with source data unchanged and temporary resources removed;
- two-person approval in both requester/approver directions;
- durable dispatch and production restore into a disposable PostgreSQL target;
- final `/ready` reports migrations, bootstrap, and Temporal worker healthy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import existing PostgreSQL archives from approved S3-compatible storage.
  * Configure import permissions, approved prefixes, and maximum archive sizes.
  * Browse eligible destination files and register external backup artifacts.
  * Verify imported archives with isolated test restores.
  * Preview production restores and submit approval requests from the CLI or web interface.
  * View artifact status, checksums, source details, and restore progress.

* **Safety & Reliability**
  * Added validation, checksum verification, credential redaction, scoped access controls, and approval gates for production restores.
  * Added coverage for import, verification, restore, and failure-recovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->